### PR TITLE
[codex] Add new VAT annotations to filter output

### DIFF
--- a/scripts/filter_and_write_mt.py
+++ b/scripts/filter_and_write_mt.py
@@ -126,6 +126,11 @@ def main(args):
         consequence=_cast_to_str(vat_ht.consequence),
         revel=_cast_to_float(vat_ht.revel),
         aa_change=_cast_to_str(vat_ht.aa_change),
+        LoF=_cast_to_str(vat_ht.LoF),
+        LoF_filter=sanitize_info(vat_ht.LoF_filter),
+        LoF_flags=sanitize_info(vat_ht.LoF_flags),
+        LoF_info=sanitize_info(vat_ht.LoF_info),
+        GERP=_cast_to_float(vat_ht.GERP),
         rsid=_cast_to_str(vat_ht.dbsnp_rsid),
         # SpliceAI scores and distances
         splice_ai_acceptor_gain_score=_cast_to_float(vat_ht.splice_ai_acceptor_gain_score),
@@ -279,6 +284,11 @@ def main(args):
         gene_omim_id = annotations_ht._vat.gene_omim_id,
         revel = annotations_ht._vat.revel,
         aa_change = annotations_ht._vat.aa_change,
+        LoF = annotations_ht._vat.LoF,
+        LoF_filter = annotations_ht._vat.LoF_filter,
+        LoF_flags = annotations_ht._vat.LoF_flags,
+        LoF_info = annotations_ht._vat.LoF_info,
+        GERP = annotations_ht._vat.GERP,
 
         # SpliceAI scores
         splice_ai_acceptor_gain_score = annotations_ht._vat.splice_ai_acceptor_gain_score,
@@ -361,6 +371,11 @@ def main(args):
                 consequence=mt_filtered._vat.consequence,
                 revel=mt_filtered._vat.revel,
                 aa_change=mt_filtered._vat.aa_change,
+                LoF=mt_filtered._vat.LoF,
+                LoF_filter=mt_filtered._vat.LoF_filter,
+                LoF_flags=mt_filtered._vat.LoF_flags,
+                LoF_info=mt_filtered._vat.LoF_info,
+                GERP=mt_filtered._vat.GERP,
                 rsid=mt_filtered._vat.rsid,
 
                 # SpliceAI scores and distances from VAT


### PR DESCRIPTION
## Summary

Adds the newly available VAT annotations `LoF`, `LoF_filter`, `LoF_flags`, and `LoF_info` to `filter_and_write_mt.py`.

The fields are now carried through the VAT table selection, annotation TSV export, and VCF `INFO` annotation path.

## Validation

- `git diff --check`
- Python AST parse for `scripts/filter_and_write_mt.py`

Direct push to `main` was blocked by repository rules requiring pull requests, so this PR targets `main`.