### PR TITLE
[codex] Drop GERP from VAT annotations

### DIFF
--- a/scripts/filter_and_write_mt.py
+++ b/scripts/filter_and_write_mt.py
@@ -130,7 +130,6 @@ def main(args):
         LoF_filter=sanitize_info(vat_ht.LoF_filter),
         LoF_flags=sanitize_info(vat_ht.LoF_flags),
         LoF_info=sanitize_info(vat_ht.LoF_info),
-        GERP=_cast_to_float(vat_ht.GERP),
         rsid=_cast_to_str(vat_ht.dbsnp_rsid),
         # SpliceAI scores and distances
         splice_ai_acceptor_gain_score=_cast_to_float(vat_ht.splice_ai_acceptor_gain_score),
@@ -288,7 +287,6 @@ def main(args):
         LoF_filter = annotations_ht._vat.LoF_filter,
         LoF_flags = annotations_ht._vat.LoF_flags,
         LoF_info = annotations_ht._vat.LoF_info,
-        GERP = annotations_ht._vat.GERP,
 
         # SpliceAI scores
         splice_ai_acceptor_gain_score = annotations_ht._vat.splice_ai_acceptor_gain_score,
@@ -375,7 +373,6 @@ def main(args):
                 LoF_filter=mt_filtered._vat.LoF_filter,
                 LoF_flags=mt_filtered._vat.LoF_flags,
                 LoF_info=mt_filtered._vat.LoF_info,
-                GERP=mt_filtered._vat.GERP,
                 rsid=mt_filtered._vat.rsid,
 
                 # SpliceAI scores and distances from VAT


### PR DESCRIPTION
## Summary

Removes `GERP` from `filter_and_write_mt.py` after the VAT annotation update.

`GERP` is no longer selected from the VAT table, exported in the annotations TSV, or added to the VCF `INFO` field. The `LoF`, `LoF_filter`, `LoF_flags`, and `LoF_info` annotations remain in place.

## Validation

- `git diff --check`
- Python AST parse for `scripts/filter_and_write_mt.py`