### PR TITLE
[codex] Normalize VCF output paths

### DIFF
--- a/scripts/ExportVCF.py
+++ b/scripts/ExportVCF.py
@@ -2,12 +2,13 @@ import hail as hl
 import argparse
 import os
 
+
+def join_cloud_path(parent, child):
+    return f"{parent.rstrip('/')}/{child.lstrip('/')}"
+
+
 def write_vcf(inputs):
-    OutputBucket = inputs['OutputBucket'] 
-    if not OutputBucket.endswith('/'):
-        OutputBucket += '/'
-    
-    OutputFilePath = OutputBucket + inputs['OutputPrefix'] + '.vcf.bgz'
+    OutputFilePath = join_cloud_path(inputs['OutputBucket'], inputs['OutputPrefix'] + '.vcf.bgz')
     print('Writing VCF to:')
     print(OutputFilePath)
 

--- a/scripts/filter_and_write_mt.py
+++ b/scripts/filter_and_write_mt.py
@@ -17,6 +17,10 @@ def _spark_local_threads(value):
     return str(parsed)
 
 
+def _join_cloud_path(parent, child):
+    return f"{parent.rstrip('/')}/{child.lstrip('/')}"
+
+
 # init
 def main(args):
     # Initialize Hail with workflow-configurable local Spark resources.
@@ -314,7 +318,7 @@ def main(args):
     )
 
     # Export annotations
-    annotations_tsv = f'{args.OutputBucket}/{args.OutputPrefix}.annotations.tsv.bgz'
+    annotations_tsv = _join_cloud_path(args.OutputBucket, f'{args.OutputPrefix}.annotations.tsv.bgz')
     annotations_ht.export(annotations_tsv)
     # save to info field to export to vcf
     mt_filtered = mt_filtered.annotate_rows(
@@ -403,7 +407,7 @@ def main(args):
     
 
     # Directly export to VCF
-    OutputFilePath = f'{args.OutputBucket}/{args.OutputPrefix}.vcf.bgz'
+    OutputFilePath = _join_cloud_path(args.OutputBucket, f'{args.OutputPrefix}.vcf.bgz')
     hl.export_vcf(mt_filtered, OutputFilePath)
 
     with open('outpath.txt', 'w') as file:


### PR DESCRIPTION
## Summary

Prevents double slashes in generated output paths when `OutputBucket` already ends with `/`.

- Adds a small cloud-path join helper in `filter_and_write_mt.py`
- Uses it for both the annotations TSV and VCF output paths
- Applies the same path normalization to the legacy `ExportVCF.py` writer

This fixes paths like:

`gs://.../checkpoints//AoU.COMB_10k...vcf.bgz`

so they are written as:

`gs://.../checkpoints/AoU.COMB_10k...vcf.bgz`

## Validation

- Python AST parse for `scripts/filter_and_write_mt.py` and `scripts/ExportVCF.py`
- `git diff --check`
- Explicit trailing-slash path join check using the reported GCS prefix
- `miniwdl check main.wdl` (passes with existing `FileCoercion` warning for `IndexVCF.VCF`)
- `miniwdl check workflow/FilterMT.wdl`
- `miniwdl check workflow/MTtoVCF.wdl`