### PR TITLE
[codex] Add optional VCF post-processing outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ This is the main, all-in-one workflow. It filters the matrix table, annotates va
 | `SparkDriverMemory` | Spark/Hail driver memory inside the task (default: `64g`) |
 | `SparkParallelism` | Spark default parallelism (default: 100) |
 | `SparkShufflePartitions` | Spark SQL shuffle partitions (default: 100) |
+| `MakeDosage` | If `true`, convert the exported VCF to a genotype dosage TSV (default: `false`; `main.wdl` only) |
+| `MakePlink` | If `true`, convert the exported VCF to PLINK 2 pgen/pvar/psam files (default: `false`; `main.wdl` only) |
+| `DosageThreads` | Threads for the optional bcftools dosage task (default: 4; `main.wdl` only) |
+| `PlinkNewIdMaxAlleleLen` | Value passed to PLINK 2 `--new-id-max-allele-len` (default: 200; `main.wdl` only) |
 
 When running through `main.wdl`, these filter-task runtime inputs are exposed with a `Filter` prefix: `FilterTaskCpu`, `FilterTaskMemory`, `FilterTaskDisk`, `FilterSparkDriverMemory`, `FilterSparkParallelism`, and `FilterSparkShufflePartitions`.
 
@@ -70,6 +74,8 @@ Override these values upward when a larger runtime configuration is available.
 | `splice_ai_donor_gain_distance` / `_loss_distance` | SpliceAI donor gain/loss distances |
 
 **Output:** A bgzipped VCF (`<OutputPrefix>.vcf.bgz`) written to `<OutputBucket>`.
+
+When running through `main.wdl`, the exported VCF is always indexed. If `MakeDosage` is enabled, the workflow also emits `<FullPrefix>.dose.tsv.gz` and its `.tbi` index. If `MakePlink` is enabled, it emits `<FullPrefix>.pgen`, `<FullPrefix>.pvar`, and `<FullPrefix>.psam`.
 
 ---
 

--- a/main.wdl
+++ b/main.wdl
@@ -1,6 +1,7 @@
 version 1.0
 
 import "workflow/FilterMT.wdl" as FilterMT
+import "workflow/VCFPostProcess.wdl" as VCFPostProcess
 
 task IndexVCF {
     input {
@@ -56,6 +57,12 @@ workflow FilterMTAndExportToVCF{
         String FilterSparkDriverMemory = "64g"
         Int FilterSparkParallelism = 100
         Int FilterSparkShufflePartitions = 100
+
+        # Optional VCF post-processing
+        Boolean MakeDosage = false
+        Boolean MakePlink = false
+        Int DosageThreads = 4
+        Int PlinkNewIdMaxAlleleLen = 200
     }
 
     String FullPrefix = "~{OutputPrefix}.~{SampleSetName}.AC~{MinAlleleCountThreshold}.AN~{AlleleNumberPercentage}.biallelic.~{CallSetName}"
@@ -80,18 +87,31 @@ workflow FilterMTAndExportToVCF{
             SparkParallelism = FilterSparkParallelism,
             SparkShufflePartitions = FilterSparkShufflePartitions
     }
-        
-    
-    
+
    call IndexVCF {
-        input: 
+        input:
             VCF = filter.PathVCF,
             Prefix = FullPrefix
-    } 
-    
+    }
+
+   call VCFPostProcess.VCFPostProcess as postprocess {
+        input:
+            vcf_file = filter.PathVCF,
+            output_prefix = FullPrefix,
+            make_dosage = MakeDosage,
+            make_plink = MakePlink,
+            dosage_threads = DosageThreads,
+            plink_new_id_max_allele_len = PlinkNewIdMaxAlleleLen
+    }
+
     output {
-        String PathVCF = filter.PathVCF
+        File PathVCF = filter.PathVCF
         File Index = IndexVCF.Index
+        File? GenotypeDosage = postprocess.GenotypeDosage
+        File? GenotypeDosageIndex = postprocess.GenotypeDosageIndex
+        File? PlinkPgen = postprocess.PlinkPgen
+        File? PlinkPvar = postprocess.PlinkPvar
+        File? PlinkPsam = postprocess.PlinkPsam
     }
 }
 

--- a/workflow/FilterMT.wdl
+++ b/workflow/FilterMT.wdl
@@ -43,7 +43,7 @@ workflow FilterMT {
     }
 
     output {
-        String PathVCF = TaskFilterMT.PathVCF
+        File PathVCF = TaskFilterMT.PathVCF
     }
 }
 
@@ -98,6 +98,6 @@ task TaskFilterMT {
     }
     
     output {
-        String PathVCF = read_string('outpath.txt') 
+        File PathVCF = read_string('outpath.txt')
     }
 }

--- a/workflow/VCFPostProcess.wdl
+++ b/workflow/VCFPostProcess.wdl
@@ -1,0 +1,104 @@
+version 1.0
+
+workflow VCFPostProcess {
+    input {
+        File vcf_file
+        String output_prefix
+        Boolean make_dosage = false
+        Boolean make_plink = false
+        Int dosage_threads = 4
+        Int plink_new_id_max_allele_len = 200
+    }
+
+    if (make_dosage) {
+        call BcftoolsDosage {
+            input:
+                vcf_file = vcf_file,
+                output_prefix = output_prefix,
+                threads = dosage_threads
+        }
+    }
+
+    if (make_plink) {
+        call Plink2 {
+            input:
+                vcf_file = vcf_file,
+                output_prefix = output_prefix,
+                new_id_max_allele_len = plink_new_id_max_allele_len
+        }
+    }
+
+    output {
+        File? GenotypeDosage = BcftoolsDosage.dosage
+        File? GenotypeDosageIndex = BcftoolsDosage.dosage_index
+        File? PlinkPgen = Plink2.pgen
+        File? PlinkPvar = Plink2.pvar
+        File? PlinkPsam = Plink2.psam
+    }
+}
+
+task BcftoolsDosage {
+    input {
+        File vcf_file
+        String output_prefix
+        Int threads
+    }
+
+    command <<<
+        set -euo pipefail
+
+        printf 'CHROM\nPOS\nREF\nALT\n' > 4_columns.tsv
+        bcftools query -l "~{vcf_file}" > sample_list.tsv
+        cat 4_columns.tsv sample_list.tsv > header.tsv
+        csvtk transpose header.tsv -T | gzip > header_row.tsv.gz
+
+        bcftools +dosage --threads ~{threads} "~{vcf_file}" -- -t GT | tail -n+2 | gzip > dose_matrix.tsv.gz
+        zcat header_row.tsv.gz dose_matrix.tsv.gz | bgzip > "~{output_prefix}.dose.tsv.gz"
+        tabix -s1 -b2 -e2 -S1 "~{output_prefix}.dose.tsv.gz"
+    >>>
+
+    runtime {
+        docker: "quay.io/eqtlcatalogue/susie-finemapping:v20.08.1"
+        memory: "32G"
+        cpu: threads
+        disks: "local-disk 500 SSD"
+    }
+
+    output {
+        File dosage = "~{output_prefix}.dose.tsv.gz"
+        File dosage_index = "~{output_prefix}.dose.tsv.gz.tbi"
+    }
+}
+
+task Plink2 {
+    input {
+        File vcf_file
+        String output_prefix
+        Int new_id_max_allele_len
+    }
+
+    command <<<
+        set -euo pipefail
+
+        plink2 --vcf "~{vcf_file}" \
+            --make-pgen \
+            --out "~{output_prefix}" \
+            --set-all-var-ids @:#_\$r_\$a \
+            --new-id-max-allele-len "~{new_id_max_allele_len}" \
+            --output-chr chrM \
+            --chr 1-22
+    >>>
+
+    runtime {
+        docker: "quay.io/biocontainers/plink2:2.0.0a.6.9--h9948957_0"
+        memory: "96G"
+        cpu: 4
+        disks: "local-disk 400 SSD"
+    }
+
+    output {
+        File pgen = "~{output_prefix}.pgen"
+        File pvar = "~{output_prefix}.pvar"
+        File psam = "~{output_prefix}.psam"
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional downstream post-processing of the exported VCF in `main.wdl`.

- Adds `workflow/VCFPostProcess.wdl` with a bcftools dosage task and a PLINK 2 conversion task adapted from the prepare_QTL workflows
- Adds `MakeDosage`, `MakePlink`, `DosageThreads`, and `PlinkNewIdMaxAlleleLen` inputs to `main.wdl`
- Emits optional dosage outputs (`.dose.tsv.gz`, `.tbi`) and PLINK outputs (`.pgen`, `.pvar`, `.psam`)
- Changes `FilterMT.PathVCF` from `String` to `File` so the index and optional post-processing tasks consume the exported VCF directly
- Documents the new optional inputs and outputs in the README

## Validation

- `miniwdl check workflow/VCFPostProcess.wdl`
- `miniwdl check main.wdl`
- `miniwdl check workflow/FilterMT.wdl`
- `git diff --check`

Referenced workflows:

- https://github.com/AoU-Multiomics-Analysis/prepare_QTL/blob/main/workflows/calculateGenotypeDosage.wdl
- https://github.com/AoU-Multiomics-Analysis/prepare_QTL/blob/main/workflows/convertVCF2Plink.wdl