### PR TITLE
[codex] Use bcftools-native VCF indexing

### DIFF
--- a/main.wdl
+++ b/main.wdl
@@ -11,8 +11,8 @@ task IndexVCF {
    
     command <<<
         set -euo pipefail
-        bcftools index -p vcf ~{VCF}
-    >>>   
+        bcftools index --tbi --force "~{VCF}"
+    >>>
     
     runtime {
         docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils" 


### PR DESCRIPTION
## Summary

Updates the `IndexVCF` task to use bcftools-native indexing flags instead of the tabix-style `-p vcf` argument.

- Replaces `bcftools index -p vcf ~{VCF}` with `bcftools index --tbi --force "~{VCF}"`
- Keeps producing the expected `.vcf.bgz.tbi` index output

## Validation

- `miniwdl check main.wdl`
- `git diff --check`