### PR TITLE
[codex] Write IndexVCF output index explicitly

### DIFF
--- a/main.wdl
+++ b/main.wdl
@@ -11,7 +11,9 @@ task IndexVCF {
    
     command <<<
         set -euo pipefail
-        bcftools index --tbi --force "~{VCF}"
+        bcftools index --tbi --force \
+            --output "~{Prefix}.vcf.bgz.tbi" \
+            "~{VCF}"
     >>>
     
     runtime {


### PR DESCRIPTION
## Summary
- Update `IndexVCF` to pass `--output "~{Prefix}.vcf.bgz.tbi"` to `bcftools index`
- Keep the existing WDL `File Index` output path unchanged

## Why
The previous command let `bcftools` create the index next to the localized VCF input. In Cromwell, that can leave the expected `~{Prefix}.vcf.bgz.tbi` output absent from the task working directory even if indexing itself succeeds.

## Validation
- `miniwdl check main.wdl`
- `git diff --check`