### PR TITLE
Export transcript-level VAT annotations

### DIFF
--- a/.superpowers/sdd/2026-08-10-vat-transcript-annotations/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-10-vat-transcript-annotations/final-fix-report.md
@@ -1,0 +1,174 @@
+# VAT Transcript Annotation Final Fix Report
+
+## Status
+
+COMPLETE_WITH_RESIDUAL_LIMITATION
+
+The reviewed Hail defects are fixed in commit `adb28b0` (`fix: harden VAT transcript annotation export`). Real Hail and miniwdl regressions were added and executed successfully before the final status guard. Per the final instruction, no further Docker or integration command was run after that guard; only fast local checks were repeated before commit.
+
+## Files changed
+
+- `scripts/filter_and_write_mt.py`
+- `tests/test_filter_and_write_mt_hail_integration.py`
+- `tests/test_filtermt_optional_output_smoke.py`
+- `tests/wdl/filtermt_optional_output_smoke.wdl`
+- `README.md`
+- `docs/superpowers/plans/2026-08-10-vat-transcript-annotations-final-fix.md`
+- `.superpowers/sdd/2026-08-10-vat-transcript-annotations/final-fix-report.md` (this report)
+
+## Finding resolutions
+
+### 1. Composite-key VAT protected field
+
+Resolved. `_prepare_vat_tables` validates the source row schema first, then calls `vat_source_ht.key_by()` before parsing or projecting fields. This preserves `vid` and `transcript` as ordinary row fields while removing their protected source-key status. The existing variant-level projection is still returned with key `(locus, alleles)`, and its downstream selection and VCF INFO contract were not changed.
+
+The real Hail fixture is written with source key `(vid, transcript)`. Before the fix, Hail failed at the transcript projection with:
+
+```text
+hail.expr.expressions.base_expression.ExpressionException:
+'Table.select': cannot overwrite key field 'transcript' with annotate, select or drop; use key_by to modify keys.
+```
+
+After source-key normalization, the test progressed through `_prepare_vat_tables` and failed only because the new transcript-preparation helper had not yet been added, establishing the isolated red/green transition.
+
+### 2. Deterministic genomic/transcript ordering
+
+Resolved. `_prepare_transcript_annotations` performs the existing Hail semi-join, annotates flat variant identity fields, then explicitly calls:
+
+```python
+order_by(locus, alleles, transcript)
+```
+
+Only afterward does it select the approved flat output fields. Hail `order_by` unkeys the table while retaining an explicit sorted execution plan, so export contains exactly the approved 17 columns rather than key-only helper columns.
+
+The pinned regression asserts both exported row order and the executed Hail IR sort fields. During mutation testing, replacing the explicit sort with the reviewed empty `key_by()` caused the test to fail because the outer sort remained descending rather than the required ascending sort:
+
+```text
+[('locus', 'A'), ('alleles', 'A'), ('transcript', 'D')]
+!=
+[('locus', 'A'), ('alleles', 'A'), ('transcript', 'A')]
+```
+
+Restoring `order_by` returned the pinned test to green.
+
+### 3. Real pinned-Hail regression coverage
+
+Resolved. `tests/test_filter_and_write_mt_hail_integration.py` runs production helpers under `hailgenetics/hail:0.2.134-py3.11` and covers:
+
+- a VAT Hail Table keyed by `(vid, transcript)`;
+- two transcript rows for one retained variant, both preserved;
+- an intergenic row with missing transcript/gene values, retained;
+- one filtered-out variant, absent from output;
+- the exact approved columns in exact order;
+- explicit ascending `(locus, alleles, transcript)` Hail ordering;
+- genomic order in the exported BGZF file.
+
+The integration test skips under the host unit-test interpreter when real Hail is unavailable and runs when invoked in the pinned image.
+
+Controller rerun command (requires Docker daemon approval):
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v "$PWD:/workspace" -w /workspace \
+  hailgenetics/hail:0.2.134-py3.11 \
+  python3 -m unittest tests.test_filter_and_write_mt_hail_integration -v
+```
+
+The first unapproved sandbox attempt produced this exact daemon denial:
+
+```text
+docker: permission denied while trying to connect to the Docker daemon socket at unix:///Users/evinmpadhi/.docker/run/docker.sock: Post "http://%2FUsers%2Fevinmpadhi%2F.docker%2Frun%2Fdocker.sock/v1.24/containers/create?platform=linux%2Famd64": dial unix /Users/evinmpadhi/.docker/run/docker.sock: connect: operation not permitted.
+```
+
+After approval, the pinned image was pulled and the final green run completed:
+
+```text
+Ran 1 test in 33.288s
+OK
+```
+
+Hail emitted its upstream Java illegal-reflective-access warnings, but the process exited 0.
+
+### 4. `AnnotateWithVAT=false` optional output
+
+Resolved to the smallest meaningful executable regression. The smoke fixture uses the production WDL 1.0 optional-output expression, and the Python test first verifies that the fixture declaration matches `workflow/FilterMT.wdl`. It then executes the fixture with miniwdl and Docker while creating no transcript path file, and asserts that `FilterMTOptionalOutputSmoke.TranscriptAnnotations` is JSON `null`.
+
+Command and result:
+
+```bash
+python3 -m unittest tests.test_filtermt_optional_output_smoke -v
+```
+
+```text
+Ran 1 test in 2.118s
+OK
+```
+
+This tests the intended available WDL engine's optional-file behavior without fabricating a full production MatrixTable/cloud run.
+
+### 5. README input-schema migration
+
+Resolved. README now lists the required transcript source VAT fields (`vid`, `dbsnp_rsid`, `gene_id`, `gene_symbol`, `transcript`, `is_canonical_transcript`, `consequence`, `aa_change`, `LoF`, `LoF_filter`, `LoF_flags`, `LoF_info`, `gvs_max_af`, and `gvs_max_subpop`), documents validation before projection and the complete missing-field error, confirms composite source keys are accepted, and directs users to regenerate older precomputed VAT tables that lack these columns. It also documents the pinned Hail and miniwdl smoke commands.
+
+## Red/green evidence
+
+1. Pinned Hail RED: protected `transcript` key field exception.
+2. Key-normalization intermediate RED: `_prepare_vat_tables` succeeded, then `_prepare_transcript_annotations` was absent.
+3. Ordering mutation RED: old empty-key behavior failed the required ascending Hail IR assertion.
+4. Pinned Hail GREEN: one integration test passed in 33.288 seconds.
+5. miniwdl optional-output GREEN: one executable smoke test passed in 2.118 seconds and returned null.
+
+## Validation
+
+Baseline before edits:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m py_compile scripts/filter_and_write_mt.py scripts/tsv_gz_to_hail_table.py scripts/ExportVCF.py
+miniwdl check main.wdl workflow/FilterMT.wdl workflow/TSVtoHailTable.wdl workflow/MTtoVCF.wdl workflow/VCFPostProcess.wdl
+git diff --check
+```
+
+Result: 5/5 existing tests passed, compilation exited 0, all five WDL documents checked successfully, and the diff check was clean.
+
+Complete host suite after implementation (before the final status guard):
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+Result: 7 tests discovered; 6 passed and the real Hail test was intentionally skipped outside the pinned image. The included miniwdl/Docker smoke passed.
+
+Final fast local verification after the status guard:
+
+```bash
+python3 -m unittest tests.test_filter_and_write_mt_contract -v
+python3 -m py_compile scripts/filter_and_write_mt.py scripts/tsv_gz_to_hail_table.py scripts/ExportVCF.py tests/test_filter_and_write_mt_contract.py tests/test_filter_and_write_mt_hail_integration.py tests/test_filtermt_optional_output_smoke.py
+miniwdl check main.wdl workflow/FilterMT.wdl workflow/TSVtoHailTable.wdl workflow/MTtoVCF.wdl workflow/VCFPostProcess.wdl tests/wdl/filtermt_optional_output_smoke.wdl
+git diff --check
+```
+
+Result: 5/5 focused tests passed, all listed Python files compiled, all five required WDL files plus the smoke fixture checked successfully, and `git diff --check` exited 0.
+
+## Commits
+
+- `adb28b0` — `fix: harden VAT transcript annotation export`
+- This report is committed immediately after creation; its own immutable hash cannot be embedded in its contents and is included in the final task response.
+
+## Self-review
+
+- Reviewed the complete final-wave diff against `9d94bde` and the full feature diff against `b8efb6a`.
+- Confirmed existing `<OutputPrefix>.vcf.bgz` and `<OutputPrefix>.annotations.tsv.bgz` names are unchanged.
+- Confirmed existing variant-level annotation field selection and VCF INFO selection are unchanged by the final wave.
+- Confirmed transcript filtering remains a Hail semi-join against retained MatrixTable row keys and does not expand the MatrixTable or collect annotations on the driver.
+- Confirmed the transcript file exports exactly `chrom`, `pos`, `ref`, `alt`, `rsid`, `gene_id`, `gene_symbol`, `transcript`, `is_canonical_transcript`, `consequence`, `aa_change`, `LoF`, `LoF_filter`, `LoF_flags`, `LoF_info`, `gvs_max_af`, and `gvs_max_subpop` in that order.
+- Confirmed intergenic rows remain and two same-variant transcript rows remain separate.
+- Confirmed no consequence ranking or Ensembl ID normalization was added upstream.
+- Confirmed VAT reading/schema validation and transcript export remain disabled when `AnnotateWithVAT=false`.
+- Confirmed only requested final-wave files were staged in the implementation commit.
+
+## Residual concerns
+
+- No full production `TaskFilterMT` run was performed because no production MatrixTable, sample list, VAT cloud table, credentials, or cloud output paths were supplied. The real pinned-Hail helper integration and miniwdl optional-output execution cover the defects without inventing those inputs.
+- The controller should rerun the exact pinned-Docker command above with daemon approval on the committed tree, per the final status guard.
+- The production-pinned Hail image emits Java illegal-reflective-access warnings under its bundled Spark/JVM stack; these warnings did not affect the successful test exit.

--- a/README.md
+++ b/README.md
@@ -91,9 +91,32 @@ and/or `transcript`. Transcript annotations are filtered to retained variants
 without expanding the MatrixTable. Downstream analyses should choose the most
 severe consequence for the matched gene when collapsing transcript-level rows.
 
+The source VAT Hail Table must include `vid`, `dbsnp_rsid`, `gene_id`,
+`gene_symbol`, `transcript`, `is_canonical_transcript`, `consequence`,
+`aa_change`, `LoF`, `LoF_filter`, `LoF_flags`, `LoF_info`, `gvs_max_af`, and
+`gvs_max_subpop` in addition to the fields already used by the variant-level
+annotations. The table may be keyed by `(vid, transcript)`. When
+`AnnotateWithVAT=true`, these transcript fields are validated before any Hail
+projection; a missing-field error lists every absent field. Older precomputed
+VAT Hail Tables that lack any of these columns must be regenerated from a VAT
+export containing them. No VAT schema validation occurs when annotation is
+disabled.
+
 When running through `main.wdl`, the exported VCF is always indexed. If `MakeDosage` is enabled, the workflow also emits `<FullPrefix>.dose.tsv.gz` and its `.tbi` index. If `MakePlink` is enabled, it emits `<FullPrefix>.pgen`, `<FullPrefix>.pvar`, and `<FullPrefix>.psam`.
 
 For pipeline testing without VAT, set `AnnotateWithVAT = false` and omit `VATHailTable`. The annotations TSV and VCF still include filtered cohort statistics and variant QC fields, but VAT-derived fields are omitted.
+
+Run the real transcript-export regression in the production-pinned Hail image:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v "$PWD:/workspace" -w /workspace \
+  hailgenetics/hail:0.2.134-py3.11 \
+  python3 -m unittest tests.test_filter_and_write_mt_hail_integration -v
+```
+
+With miniwdl and Docker available, smoke-test the disabled-VAT optional output
+with `python3 -m unittest tests.test_filtermt_optional_output_smoke -v`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ Override these values upward when a larger runtime configuration is available.
 
 **Output:** A bgzipped VCF (`<OutputPrefix>.vcf.bgz`) written to `<OutputBucket>`.
 
+The workflow also writes the following annotation outputs:
+
+- `<OutputPrefix>.annotations.tsv.bgz`: existing one-row-per-variant annotations.
+- `<OutputPrefix>.transcript_annotations.tsv.bgz`: one row per retained
+  variant-transcript combination, emitted when `AnnotateWithVAT=true` and
+  exposed as the optional `TranscriptAnnotations` WDL output.
+
+The transcript annotations TSV contains `chrom`, `pos`, `ref`, `alt`, `rsid`,
+`gene_id`, `gene_symbol`, `transcript`, `is_canonical_transcript`,
+`consequence`, `aa_change`, `LoF`, `LoF_filter`, `LoF_flags`, `LoF_info`,
+`gvs_max_af`, and `gvs_max_subpop`. Intergenic rows may have missing `gene_id`
+and/or `transcript`. Transcript annotations are filtered to retained variants
+without expanding the MatrixTable. Downstream analyses should choose the most
+severe consequence for the matched gene when collapsing transcript-level rows.
+
 When running through `main.wdl`, the exported VCF is always indexed. If `MakeDosage` is enabled, the workflow also emits `<FullPrefix>.dose.tsv.gz` and its `.tbi` index. If `MakePlink` is enabled, it emits `<FullPrefix>.pgen`, `<FullPrefix>.pvar`, and `<FullPrefix>.psam`.
 
 For pipeline testing without VAT, set `AnnotateWithVAT = false` and omit `VATHailTable`. The annotations TSV and VCF still include filtered cohort statistics and variant QC fields, but VAT-derived fields are omitted.

--- a/docs/plans/2026-08-10-vat-transcript-annotations-design.md
+++ b/docs/plans/2026-08-10-vat-transcript-annotations-design.md
@@ -1,0 +1,97 @@
+# VAT Transcript Annotation Export Design
+
+## Context
+
+The All of Us Variant Annotation Table (VAT) contains one row per
+variant-transcript combination, keyed by `vid` and `transcript`. The current
+MTtoVCF filtering workflow rekeys VAT rows by variant (`locus`, `alleles`) for
+annotation of a variant-level MatrixTable. Consequently, the exported
+`<prefix>.annotations.tsv.bgz` does not retain the gene and transcript identity
+needed for gene-matched rare-variant enrichment.
+
+The existing VCF and annotations TSV are consumed as one-row-per-variant
+artifacts. Changing either artifact to transcript-level rows would be a breaking
+change.
+
+## Decision
+
+Preserve all existing outputs and add a companion transcript-level annotation
+file:
+
+`<OutputPrefix>.transcript_annotations.tsv.bgz`
+
+The companion file will contain every VAT variant-transcript row whose variant
+survives the existing MTtoVCF filters. The genotype MatrixTable will remain at
+one row per variant.
+
+## Output contract
+
+Each row represents one retained variant-transcript combination. The output
+will include:
+
+- Variant identity: `chrom`, `pos`, `ref`, `alt`, `rsid`
+- Gene/transcript identity: `gene_id`, `gene_symbol`, `transcript`,
+  `is_canonical_transcript`
+- Functional annotation: `consequence`, `aa_change`, `LoF`, `LoF_filter`,
+  `LoF_flags`, `LoF_info`
+- Population rarity fields: `gvs_max_af`, `gvs_max_subpop`
+
+Rows with no overlapping transcript, such as intergenic variants, may contain
+missing gene and transcript values and will be retained. Downstream gene-matched
+analyses can discard those rows.
+
+The transcript annotations output is optional at the WDL interface. It is
+present when `AnnotateWithVAT=true` and absent when VAT annotation is disabled.
+
+## Processing design
+
+1. Read the VAT Hail Table once and parse `vid` into GRCh38 `locus` and
+   biallelic `alleles` using the current contig-normalization behavior.
+2. Retain the current variant-level VAT projection for the existing VCF and
+   annotations TSV without changing their schemas or names.
+3. Build a second transcript-level projection containing the output fields
+   above and key it by variant for filtering.
+4. After all current MatrixTable filters have run, create a key-only Hail Table
+   from the retained MatrixTable rows.
+5. Semi-join the transcript-level VAT projection to those retained variant keys.
+   This filters annotations without expanding the genotype MatrixTable and
+   avoids collecting chromosome-scale annotations in driver memory.
+6. Export the companion BGZF TSV to `OutputBucket` and expose its path through
+   `workflow/FilterMT.wdl` and `main.wdl`.
+
+The export will remain ordered by genomic variant key so it can be indexed or
+streamed efficiently by downstream workflows.
+
+## Validation and failures
+
+When `AnnotateWithVAT=true`, the script will validate that the input VAT Hail
+Table contains all fields required by the companion output. Missing fields will
+cause an early error listing the absent columns. When VAT annotation is disabled,
+no transcript schema validation or transcript export will occur.
+
+The implementation will verify:
+
+- Existing WDL files continue to pass `miniwdl check`.
+- Python source compiles.
+- Field-contract tests cover required VAT columns, optional VAT behavior, and
+  propagation of the new optional output through both WDL workflow layers.
+- Existing VCF and variant-level annotation names and schemas remain unchanged.
+
+## Downstream responsibility
+
+RareVariantEnrichment will match version-normalized Ensembl gene IDs from this
+file to the versioned Ensembl IDs in the expression BED. It will collapse
+multiple transcript rows to the most severe consequence for the matched gene.
+That analysis policy remains downstream so no transcript information is lost in
+MTtoVCF.
+
+## Alternatives rejected
+
+- **Replace the current annotations TSV with transcript rows:** rejected because
+  it would duplicate variants and break existing one-row-per-variant consumers.
+- **Collapse to one consequence per gene in MTtoVCF:** rejected because it would
+  discard transcript detail and hard-code consequence-ranking policy into the
+  extraction workflow.
+- **Encode all transcript annotations in VCF INFO:** rejected because nested
+  transcript records are awkward to represent, inflate the VCF, and complicate
+  downstream parsing.

--- a/docs/superpowers/plans/2026-08-10-vat-transcript-annotations-final-fix.md
+++ b/docs/superpowers/plans/2026-08-10-vat-transcript-annotations-final-fix.md
@@ -1,0 +1,132 @@
+# VAT Transcript Annotation Final Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the final Hail correctness findings for composite-key VAT inputs and deterministic transcript export, add executable pinned-Hail and WDL regressions, and document the VAT schema migration.
+
+**Architecture:** Validate the complete source VAT row schema, then remove its source key before any projection so `(vid, transcript)` inputs cannot protect projected fields. Keep the transcript table keyed by genomic variant for the semi-join, then explicitly `order_by` genomic locus, alleles, and transcript before selecting the approved flat export columns. Exercise the production Hail helpers in the pinned production image and execute the optional WDL output expression with miniwdl.
+
+**Tech Stack:** Python 3.11, Hail 0.2.134, WDL 1.0, miniwdl 1.14.2, Docker, standard-library `unittest`
+
+## Global Constraints
+
+- Preserve the existing VCF and `<OutputPrefix>.annotations.tsv.bgz` names and schemas.
+- Preserve exactly the approved transcript output columns and order.
+- Retain every matching VAT row, including duplicate transcript rows and intergenic rows.
+- Order transcript output by GRCh38 locus, alleles, and transcript; do not rely on an empty `key_by()`.
+- Keep consequence ranking and Ensembl normalization downstream.
+- Emit the optional transcript output only when `AnnotateWithVAT=true`.
+- Use `hailgenetics/hail:0.2.134-py3.11` for the real Hail integration test.
+
+---
+
+### Task 1: Composite-key and deterministic-order Hail regression
+
+**Files:**
+- Create: `tests/test_filter_and_write_mt_hail_integration.py`
+- Modify: `scripts/filter_and_write_mt.py`
+
+**Interfaces:**
+- Consumes: a VAT Hail Table whose source key is `(vid, transcript)` and a retained-variant key table keyed by `(locus, alleles)`.
+- Produces: `_prepare_vat_tables(path)` projections without protected source keys and `_prepare_transcript_annotations(transcript_ht, retained_keys)` with the approved flat schema and explicit genomic/transcript order.
+
+- [ ] **Step 1: Write a real Hail integration test**
+
+Create a five-row VAT fixture in deliberately non-genomic order: two transcript rows for one retained variant, one intergenic row, one later retained variant, and one filtered-out variant. Key the fixture by `vid` and `transcript`, call the production helpers, export BGZF, and assert the literal 17-column header, retained duplicate-variant row multiplicity, intergenic row, excluded variant, and genomic/transcript row order.
+
+- [ ] **Step 2: Run the pinned-image test and verify RED**
+
+Run:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v "$PWD:/workspace" -w /workspace \
+  hailgenetics/hail:0.2.134-py3.11 \
+  python3 -m unittest tests.test_filter_and_write_mt_hail_integration -v
+```
+
+Expected: FAIL in `_prepare_vat_tables` because `transcript` is a protected key field.
+
+- [ ] **Step 3: Normalize the VAT source key**
+
+After validating all required row fields, call `vat_source_ht.key_by()` before parsing and projecting fields. Do not alter the returned variant-level projection schema.
+
+- [ ] **Step 4: Verify the protected-key failure is gone**
+
+Re-run the pinned-image test. Expected: progress past `_prepare_vat_tables` and fail because `_prepare_transcript_annotations` is not yet implemented.
+
+- [ ] **Step 5: Implement deterministic transcript preparation**
+
+Move the semi-join, flat identity annotation, explicit `order_by(locus, alleles, transcript)`, and approved-column `select` into `_prepare_transcript_annotations`. Call it from `main`; do not change variant-level annotation selection or VCF INFO selection.
+
+- [ ] **Step 6: Verify GREEN**
+
+Re-run the pinned-image test. Expected: PASS with all five test requirements asserted from the exported BGZF.
+
+---
+
+### Task 2: Optional WDL output execution smoke
+
+**Files:**
+- Create: `tests/wdl/filtermt_optional_output_smoke.wdl`
+- Create: `tests/test_filtermt_optional_output_smoke.py`
+
+**Interfaces:**
+- Consumes: the `TaskFilterMT.TranscriptAnnotations` output declaration from `workflow/FilterMT.wdl`.
+- Produces: an executable miniwdl smoke proving the absent local path resolves to JSON `null` when `AnnotateWithVAT=false`.
+
+- [ ] **Step 1: Add the executable regression**
+
+Create a minimal WDL 1.0 workflow with the same optional-output expression and a command that creates no transcript path file. Add a Python test that first verifies the production declaration matches the fixture, then runs miniwdl and asserts the output is null.
+
+- [ ] **Step 2: Run the smoke test**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_filtermt_optional_output_smoke -v
+```
+
+Expected: PASS when Docker daemon access is available. If sandbox access is denied, retain the runnable test and record the exact daemon error and command in the final report.
+
+---
+
+### Task 3: Input schema migration documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `REQUIRED_TRANSCRIPT_VAT_FIELDS` and `_prepare_vat_tables` validation behavior.
+- Produces: user-facing source-field requirements, early failure behavior, and regeneration guidance for older precomputed VAT tables.
+
+- [ ] **Step 1: Document required VAT fields and migration**
+
+List `vid`, `dbsnp_rsid`, `gene_id`, `gene_symbol`, `transcript`, `is_canonical_transcript`, `consequence`, `aa_change`, `LoF`, `LoF_filter`, `LoF_flags`, `LoF_info`, `gvs_max_af`, and `gvs_max_subpop`. State that validation occurs before projection and missing fields are listed in an early error; older tables must be regenerated from a VAT export containing these columns.
+
+---
+
+### Task 4: Verification, review, report, and commit
+
+**Files:**
+- Create: `.superpowers/sdd/2026-08-10-vat-transcript-annotations/final-fix-report.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-3 and the approved design/review package.
+- Produces: fresh verification evidence, self-review, independent review when tooling permits, a detailed report, and one coherent commit or small commit set.
+
+- [ ] **Step 1: Run focused and complete verification**
+
+Run the focused unit tests, pinned-Hail Docker test, all unit tests, Python compilation, all five `miniwdl check` targets, the optional-output miniwdl smoke, `git diff --check`, and scoped diffs against `9d94bde` and `b8efb6a`.
+
+- [ ] **Step 2: Review the complete diff**
+
+Check every finding against code and executable evidence; confirm the existing VCF and variant-level names/selections are unchanged, no upstream consequence ranking was added, and no unrelated changes entered the wave.
+
+- [ ] **Step 3: Write the final report**
+
+Record status, files, each finding, red/green evidence, exact Docker/Hail and WDL commands/results, commits, self-review, and residual concerns.
+
+- [ ] **Step 4: Commit**
+
+Stage only the final-fix files and commit with an intentional message. Re-run final verification on the committed tree before reporting status.

--- a/docs/superpowers/plans/2026-08-10-vat-transcript-annotations.md
+++ b/docs/superpowers/plans/2026-08-10-vat-transcript-annotations.md
@@ -1,0 +1,348 @@
+# VAT Transcript Annotation Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a non-breaking, transcript-level VAT annotation TSV for every variant retained by MTtoVCF and expose it as an optional WDL output.
+
+**Architecture:** Read and parse the VAT Hail Table once, then derive the existing variant-level projection and a new transcript-level projection. Semi-join transcript rows to the filtered MatrixTable's variant keys and export them without expanding genotype rows; propagate the resulting cloud path through both WDL workflow layers.
+
+**Tech Stack:** Python 3, Hail, WDL 1.0, miniwdl, standard-library `unittest`
+
+## Global Constraints
+
+- Preserve the existing VCF and `<OutputPrefix>.annotations.tsv.bgz` names and schemas.
+- Emit `<OutputPrefix>.transcript_annotations.tsv.bgz` only when `AnnotateWithVAT=true`.
+- Include `chrom`, `pos`, `ref`, `alt`, `rsid`, `gene_id`, `gene_symbol`, `transcript`, `is_canonical_transcript`, `consequence`, `aa_change`, `LoF`, `LoF_filter`, `LoF_flags`, `LoF_info`, `gvs_max_af`, and `gvs_max_subpop`.
+- Retain intergenic rows with missing transcript or gene fields.
+- Filter transcript annotations with a Hail semi-join; do not collect annotations in driver memory or expand the genotype MatrixTable.
+- Fail early with an explicit list of missing required VAT fields when VAT annotation is enabled.
+- Keep transcript consequence ranking and Ensembl version normalization downstream.
+- Add no runtime dependency beyond the repository's existing Hail image.
+
+---
+
+### Task 1: Preserve and export filtered VAT transcript rows
+
+**Files:**
+- Create: `tests/test_filter_and_write_mt_contract.py`
+- Modify: `scripts/filter_and_write_mt.py:24-197`
+- Modify: `scripts/filter_and_write_mt.py:222-357`
+
+**Interfaces:**
+- Consumes: an AoU VAT Hail Table containing `REQUIRED_TRANSCRIPT_VAT_FIELDS` and a filtered MatrixTable keyed by `locus`, `alleles`.
+- Produces: `_prepare_vat_tables(vat_hail_table) -> tuple[hl.Table, hl.Table]`, `_missing_transcript_vat_fields(available_fields) -> list[str]`, `<OutputPrefix>.transcript_annotations.tsv.bgz`, and `transcript_annotations_outpath.txt`.
+
+- [ ] **Step 1: Add failing field-contract tests**
+
+Create `tests/test_filter_and_write_mt_contract.py`:
+
+```python
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.modules.setdefault("hail", types.ModuleType("hail"))
+SPEC = importlib.util.spec_from_file_location(
+    "filter_and_write_mt", ROOT / "scripts" / "filter_and_write_mt.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TranscriptVatContractTests(unittest.TestCase):
+    def test_transcript_output_fields_are_complete(self):
+        self.assertEqual(
+            MODULE.TRANSCRIPT_ANNOTATION_FIELDS,
+            (
+                "rsid", "gene_id", "gene_symbol", "transcript",
+                "is_canonical_transcript", "consequence", "aa_change",
+                "LoF", "LoF_filter", "LoF_flags", "LoF_info",
+                "gvs_max_af", "gvs_max_subpop",
+            ),
+        )
+
+    def test_missing_required_fields_are_sorted(self):
+        available = set(MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS) - {
+            "gene_id", "transcript"
+        }
+        self.assertEqual(
+            MODULE._missing_transcript_vat_fields(available),
+            ["gene_id", "transcript"],
+        )
+
+    def test_vid_and_dbsnp_source_fields_are_required(self):
+        self.assertIn("vid", MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS)
+        self.assertIn("dbsnp_rsid", MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the tests and verify the contract is absent**
+
+Run:
+
+```bash
+python3 -m unittest tests/test_filter_and_write_mt_contract.py -v
+```
+
+Expected: FAIL because the transcript constants do not exist.
+
+- [ ] **Step 3: Add schema constants and validation**
+
+Add to `scripts/filter_and_write_mt.py`:
+
+```python
+TRANSCRIPT_ANNOTATION_FIELDS = (
+    "rsid", "gene_id", "gene_symbol", "transcript",
+    "is_canonical_transcript", "consequence", "aa_change",
+    "LoF", "LoF_filter", "LoF_flags", "LoF_info",
+    "gvs_max_af", "gvs_max_subpop",
+)
+
+REQUIRED_TRANSCRIPT_VAT_FIELDS = (
+    "vid", "dbsnp_rsid", "gene_id", "gene_symbol", "transcript",
+    "is_canonical_transcript", "consequence", "aa_change",
+    "LoF", "LoF_filter", "LoF_flags", "LoF_info",
+    "gvs_max_af", "gvs_max_subpop",
+)
+
+
+def _missing_transcript_vat_fields(available_fields):
+    return sorted(set(REQUIRED_TRANSCRIPT_VAT_FIELDS) - set(available_fields))
+```
+
+After reading the VAT, compute `available_fields = set(vat_ht.row.dtype)` so keyed
+fields such as `vid` are included. If fields are missing, raise:
+
+```python
+raise ValueError(
+    "VAT Hail Table is missing required transcript annotation fields: "
+    + ", ".join(missing_fields)
+)
+```
+
+- [ ] **Step 4: Split VAT preparation into two projections**
+
+Rename `_prepare_vat_ht` to `_prepare_vat_tables`. Preserve the current variant projection exactly. From the parsed source, build:
+
+```python
+transcript_ht = vat_source_ht.select(
+    "locus",
+    "alleles",
+    rsid=_cast_to_str(vat_source_ht.dbsnp_rsid),
+    gene_id=_cast_to_str(vat_source_ht.gene_id),
+    gene_symbol=_cast_to_str(vat_source_ht.gene_symbol),
+    transcript=_cast_to_str(vat_source_ht.transcript),
+    is_canonical_transcript=_cast_to_str(vat_source_ht.is_canonical_transcript),
+    consequence=_cast_to_str(vat_source_ht.consequence),
+    aa_change=_cast_to_str(vat_source_ht.aa_change),
+    LoF=_cast_to_str(vat_source_ht.LoF),
+    LoF_filter=sanitize_info(vat_source_ht.LoF_filter),
+    LoF_flags=sanitize_info(vat_source_ht.LoF_flags),
+    LoF_info=sanitize_info(vat_source_ht.LoF_info),
+    gvs_max_af=_cast_to_float(vat_source_ht.gvs_max_af),
+    gvs_max_subpop=_cast_to_str(vat_source_ht.gvs_max_subpop),
+).key_by("locus", "alleles")
+```
+
+Return `(variant_ht.key_by("locus", "alleles"), transcript_ht)`. When VAT is disabled, set both variables to `None` without reading or validating VAT.
+
+- [ ] **Step 5: Semi-join and export transcript annotations**
+
+Inside `if annotate_with_vat:` after the current filters, add:
+
+```python
+filtered_variant_keys = mt_filtered.rows().select()
+transcript_annotations_ht = transcript_vat_ht.semi_join(filtered_variant_keys)
+transcript_annotations_ht = transcript_annotations_ht.annotate(
+    chrom=transcript_annotations_ht.locus.contig,
+    pos=transcript_annotations_ht.locus.position,
+    ref=transcript_annotations_ht.alleles[0],
+    alt=transcript_annotations_ht.alleles[1],
+)
+transcript_annotations_ht = transcript_annotations_ht.key_by().select(
+    "chrom", "pos", "ref", "alt", *TRANSCRIPT_ANNOTATION_FIELDS
+)
+transcript_annotations_tsv = _join_cloud_path(
+    args.OutputBucket,
+    f"{args.OutputPrefix}.transcript_annotations.tsv.bgz",
+)
+transcript_annotations_ht.export(transcript_annotations_tsv)
+with open("transcript_annotations_outpath.txt", "w") as output_path_file:
+    output_path_file.write(transcript_annotations_tsv)
+```
+
+Do not alter the existing VCF or variant-level annotation selections.
+
+- [ ] **Step 6: Run unit and syntax tests**
+
+Run:
+
+```bash
+python3 -m unittest tests/test_filter_and_write_mt_contract.py -v
+python3 -m py_compile scripts/filter_and_write_mt.py
+```
+
+Expected: three unit tests pass and Python compilation exits 0.
+
+- [ ] **Step 7: Commit the Hail export change**
+
+```bash
+git add scripts/filter_and_write_mt.py tests/test_filter_and_write_mt_contract.py
+git commit -m "feat: export transcript-level VAT annotations"
+```
+
+---
+
+### Task 2: Propagate the optional WDL output
+
+**Files:**
+- Modify: `tests/test_filter_and_write_mt_contract.py`
+- Modify: `workflow/FilterMT.wdl:47-49`
+- Modify: `workflow/FilterMT.wdl:103-105`
+- Modify: `main.wdl:111-119`
+
+**Interfaces:**
+- Consumes: `transcript_annotations_outpath.txt`, written only when `AnnotateWithVAT=true`.
+- Produces: `File? TranscriptAnnotations` from `TaskFilterMT`, `FilterMT`, and `FilterMTAndExportToVCF`.
+
+- [ ] **Step 1: Add failing WDL propagation tests**
+
+Append to `TranscriptVatContractTests`:
+
+```python
+    def test_filter_workflow_exposes_optional_transcript_output(self):
+        source = (ROOT / "workflow" / "FilterMT.wdl").read_text()
+        self.assertIn(
+            "File? TranscriptAnnotations = TaskFilterMT.TranscriptAnnotations",
+            source,
+        )
+        self.assertIn(
+            "File? TranscriptAnnotations = if AnnotateWithVAT then "
+            "read_string('transcript_annotations_outpath.txt') else None",
+            source,
+        )
+
+    def test_main_workflow_propagates_transcript_output(self):
+        source = (ROOT / "main.wdl").read_text()
+        self.assertIn(
+            "File? TranscriptAnnotations = filter.TranscriptAnnotations",
+            source,
+        )
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run `python3 -m unittest tests/test_filter_and_write_mt_contract.py -v`.
+
+Expected: the two new tests fail because the output is not exposed.
+
+- [ ] **Step 3: Add the output to `workflow/FilterMT.wdl`**
+
+Add to workflow outputs:
+
+```wdl
+File? TranscriptAnnotations = TaskFilterMT.TranscriptAnnotations
+```
+
+Add to task outputs:
+
+```wdl
+File? TranscriptAnnotations = if AnnotateWithVAT then read_string('transcript_annotations_outpath.txt') else None
+```
+
+- [ ] **Step 4: Propagate through `main.wdl`**
+
+Add to `FilterMTAndExportToVCF.output`:
+
+```wdl
+File? TranscriptAnnotations = filter.TranscriptAnnotations
+```
+
+- [ ] **Step 5: Validate tests and WDL syntax**
+
+Run:
+
+```bash
+python3 -m unittest tests/test_filter_and_write_mt_contract.py -v
+miniwdl check main.wdl workflow/FilterMT.wdl
+```
+
+Expected: five tests pass and both WDL documents validate. If miniwdl rejects `None`, use its WDL 1.0-compatible optional expression and update the exact source assertion.
+
+- [ ] **Step 6: Commit WDL propagation**
+
+```bash
+git add workflow/FilterMT.wdl main.wdl tests/test_filter_and_write_mt_contract.py
+git commit -m "feat: expose transcript annotations output"
+```
+
+---
+
+### Task 3: Document and fully verify the contract
+
+**Files:**
+- Modify: `README.md:12-85`
+
+**Interfaces:**
+- Consumes: output behavior from Tasks 1 and 2.
+- Produces: user-facing documentation for naming, row grain, schema, optional behavior, and downstream consequence collapsing.
+
+- [ ] **Step 1: Update README output documentation**
+
+Document:
+
+```markdown
+- `<OutputPrefix>.annotations.tsv.bgz`: existing one-row-per-variant annotations.
+- `<OutputPrefix>.transcript_annotations.tsv.bgz`: one row per retained
+  variant-transcript combination, emitted when `AnnotateWithVAT=true` and
+  exposed as the optional `TranscriptAnnotations` WDL output.
+```
+
+List every companion field from Global Constraints. State that intergenic rows may have missing `gene_id`/`transcript`, the MatrixTable is not expanded, and downstream analyses should choose the most severe consequence for the matched gene.
+
+- [ ] **Step 2: Run complete verification**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m py_compile scripts/filter_and_write_mt.py scripts/tsv_gz_to_hail_table.py scripts/ExportVCF.py
+miniwdl check main.wdl workflow/FilterMT.wdl workflow/TSVtoHailTable.wdl workflow/MTtoVCF.wdl workflow/VCFPostProcess.wdl
+git diff --check origin/main...HEAD
+```
+
+Expected: all tests pass, Python compilation exits 0, all five WDL files validate, and `git diff --check` emits no errors.
+
+- [ ] **Step 3: Confirm existing outputs are unchanged**
+
+Run:
+
+```bash
+git diff origin/main...HEAD -- scripts/filter_and_write_mt.py workflow/FilterMT.wdl main.wdl
+```
+
+Verify that `<OutputPrefix>.vcf.bgz` and `<OutputPrefix>.annotations.tsv.bgz` retain their names and existing fields, and the new export is guarded by `annotate_with_vat` / `AnnotateWithVAT`.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add README.md
+git commit -m "docs: describe transcript VAT annotations"
+```
+
+- [ ] **Step 5: Prepare for review**
+
+Run:
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean worktree containing the design, plan, implementation, WDL propagation, and documentation commits.

--- a/main.wdl
+++ b/main.wdl
@@ -110,6 +110,7 @@ workflow FilterMTAndExportToVCF{
 
     output {
         File PathVCF = filter.PathVCF
+        File? TranscriptAnnotations = filter.TranscriptAnnotations
         File Index = IndexVCF.Index
         File? GenotypeDosage = postprocess.GenotypeDosage
         File? GenotypeDosageIndex = postprocess.GenotypeDosageIndex

--- a/scripts/filter_and_write_mt.py
+++ b/scripts/filter_and_write_mt.py
@@ -79,28 +79,54 @@ VAT_ANNOTATION_FIELDS = (
 )
 
 
-def _prepare_vat_ht(vat_hail_table):
+TRANSCRIPT_ANNOTATION_FIELDS = (
+    "rsid", "gene_id", "gene_symbol", "transcript",
+    "is_canonical_transcript", "consequence", "aa_change",
+    "LoF", "LoF_filter", "LoF_flags", "LoF_info",
+    "gvs_max_af", "gvs_max_subpop",
+)
+
+REQUIRED_TRANSCRIPT_VAT_FIELDS = (
+    "vid", "dbsnp_rsid", "gene_id", "gene_symbol", "transcript",
+    "is_canonical_transcript", "consequence", "aa_change",
+    "LoF", "LoF_filter", "LoF_flags", "LoF_info",
+    "gvs_max_af", "gvs_max_subpop",
+)
+
+
+def _missing_transcript_vat_fields(available_fields):
+    return sorted(set(REQUIRED_TRANSCRIPT_VAT_FIELDS) - set(available_fields))
+
+
+def _prepare_vat_tables(vat_hail_table):
     # Load pre-computed VAT Hail table for annotation.
     # This table is created from the AoU Variant Annotation Table (VAT) using
     # the TSVtoHailTable workflow.
-    vat_ht = hl.read_table(vat_hail_table)
+    vat_source_ht = hl.read_table(vat_hail_table)
+    available_fields = set(vat_source_ht.row.dtype)
+    missing_fields = _missing_transcript_vat_fields(available_fields)
+    if missing_fields:
+        raise ValueError(
+            "VAT Hail Table is missing required transcript annotation fields: "
+            + ", ".join(missing_fields)
+        )
 
     # Parse the variant identifier (vid) into locus + alleles so we can join
     # with the matrix table.  Expected vid format: contig-position-ref-alt
     # Use maxsplit=3 so dashes inside allele strings are preserved.
     # The VAT may use contigs without the 'chr' prefix (e.g. '1' instead of
     # 'chr1'), so add the prefix when it is missing to match GRCh38.
-    vat_ht = vat_ht.annotate(_parts=vat_ht.vid.split('-', 4))
-    vat_ht = vat_ht.annotate(
+    vat_source_ht = vat_source_ht.annotate(_parts=vat_source_ht.vid.split('-', 4))
+    vat_source_ht = vat_source_ht.annotate(
         locus=hl.locus(
             hl.if_else(
-                vat_ht._parts[0].startswith('chr'),
-                vat_ht._parts[0],
-                'chr' + vat_ht._parts[0]
+                vat_source_ht._parts[0].startswith('chr'),
+                vat_source_ht._parts[0],
+                'chr' + vat_source_ht._parts[0]
             ),
-            hl.int32(vat_ht._parts[1]),
+            hl.int32(vat_source_ht._parts[1]),
             reference_genome='GRCh38'),
-        alleles=[vat_ht._parts[2], vat_ht._parts[3]]
+        alleles=[vat_source_ht._parts[2], vat_source_ht._parts[3]]
     )
 
     # Fixed set of VAT fields to carry forward as annotations.
@@ -122,79 +148,96 @@ def _prepare_vat_ht(vat_hail_table):
         expr = hl.if_else(hl.is_defined(expr), expr.replace('=', ':'), expr)
         return expr
 
-    vat_ht = vat_ht.select(
+    variant_ht = vat_source_ht.select(
         'locus',
         'alleles',
         # GVS population frequencies
-        gvs_all_ac=_cast_to_int(vat_ht.gvs_all_ac),
-        gvs_all_an=_cast_to_int(vat_ht.gvs_all_an),
-        gvs_all_af=_cast_to_float(vat_ht.gvs_all_af),
-        gvs_max_ac=_cast_to_int(vat_ht.gvs_max_ac),
-        gvs_max_an=_cast_to_int(vat_ht.gvs_max_an),
-        gvs_max_af=_cast_to_float(vat_ht.gvs_max_af),
-        gvs_max_subpop=_cast_to_str(vat_ht.gvs_max_subpop),
+        gvs_all_ac=_cast_to_int(vat_source_ht.gvs_all_ac),
+        gvs_all_an=_cast_to_int(vat_source_ht.gvs_all_an),
+        gvs_all_af=_cast_to_float(vat_source_ht.gvs_all_af),
+        gvs_max_ac=_cast_to_int(vat_source_ht.gvs_max_ac),
+        gvs_max_an=_cast_to_int(vat_source_ht.gvs_max_an),
+        gvs_max_af=_cast_to_float(vat_source_ht.gvs_max_af),
+        gvs_max_subpop=_cast_to_str(vat_source_ht.gvs_max_subpop),
 
         # GVS subpopulation frequencies
-        gvs_afr_af=_cast_to_float(vat_ht.gvs_afr_af),
-        gvs_amr_af=_cast_to_float(vat_ht.gvs_amr_af),
-        gvs_eas_af=_cast_to_float(vat_ht.gvs_eas_af),
-        gvs_eur_af=_cast_to_float(vat_ht.gvs_eur_af),
-        gvs_mid_af=_cast_to_float(vat_ht.gvs_mid_af),
-        gvs_sas_af=_cast_to_float(vat_ht.gvs_sas_af),
-        gvs_oth_af=_cast_to_float(vat_ht.gvs_oth_af),
+        gvs_afr_af=_cast_to_float(vat_source_ht.gvs_afr_af),
+        gvs_amr_af=_cast_to_float(vat_source_ht.gvs_amr_af),
+        gvs_eas_af=_cast_to_float(vat_source_ht.gvs_eas_af),
+        gvs_eur_af=_cast_to_float(vat_source_ht.gvs_eur_af),
+        gvs_mid_af=_cast_to_float(vat_source_ht.gvs_mid_af),
+        gvs_sas_af=_cast_to_float(vat_source_ht.gvs_sas_af),
+        gvs_oth_af=_cast_to_float(vat_source_ht.gvs_oth_af),
 
         # GVS subpopulation allele number
-        gvs_afr_an=_cast_to_float(vat_ht.gvs_afr_an),
-        gvs_amr_an=_cast_to_float(vat_ht.gvs_amr_an),
-        gvs_eas_an=_cast_to_float(vat_ht.gvs_eas_an),
-        gvs_eur_an=_cast_to_float(vat_ht.gvs_eur_an),
-        gvs_mid_an=_cast_to_float(vat_ht.gvs_mid_an),
-        gvs_sas_an=_cast_to_float(vat_ht.gvs_sas_an),
-        gvs_oth_an=_cast_to_float(vat_ht.gvs_oth_an),
+        gvs_afr_an=_cast_to_float(vat_source_ht.gvs_afr_an),
+        gvs_amr_an=_cast_to_float(vat_source_ht.gvs_amr_an),
+        gvs_eas_an=_cast_to_float(vat_source_ht.gvs_eas_an),
+        gvs_eur_an=_cast_to_float(vat_source_ht.gvs_eur_an),
+        gvs_mid_an=_cast_to_float(vat_source_ht.gvs_mid_an),
+        gvs_sas_an=_cast_to_float(vat_source_ht.gvs_sas_an),
+        gvs_oth_an=_cast_to_float(vat_source_ht.gvs_oth_an),
 
         # GVS subpopulation allele counts
-        gvs_afr_ac=_cast_to_float(vat_ht.gvs_afr_ac),
-        gvs_amr_ac=_cast_to_float(vat_ht.gvs_amr_ac),
-        gvs_eas_ac=_cast_to_float(vat_ht.gvs_eas_ac),
-        gvs_eur_ac=_cast_to_float(vat_ht.gvs_eur_ac),
-        gvs_mid_ac=_cast_to_float(vat_ht.gvs_mid_ac),
-        gvs_sas_ac=_cast_to_float(vat_ht.gvs_sas_ac),
-        gvs_oth_ac=_cast_to_float(vat_ht.gvs_oth_ac),
+        gvs_afr_ac=_cast_to_float(vat_source_ht.gvs_afr_ac),
+        gvs_amr_ac=_cast_to_float(vat_source_ht.gvs_amr_ac),
+        gvs_eas_ac=_cast_to_float(vat_source_ht.gvs_eas_ac),
+        gvs_eur_ac=_cast_to_float(vat_source_ht.gvs_eur_ac),
+        gvs_mid_ac=_cast_to_float(vat_source_ht.gvs_mid_ac),
+        gvs_sas_ac=_cast_to_float(vat_source_ht.gvs_sas_ac),
+        gvs_oth_ac=_cast_to_float(vat_source_ht.gvs_oth_ac),
 
         # gnomAD population frequencies
-        gnomad_all_ac=_cast_to_int(vat_ht.gnomad_all_ac),
-        gnomad_all_an=_cast_to_int(vat_ht.gnomad_all_an),
-        gnomad_all_af=_cast_to_float(vat_ht.gnomad_all_af),
-        gnomad_max_ac=_cast_to_int(vat_ht.gnomad_max_ac),
-        gnomad_max_an=_cast_to_int(vat_ht.gnomad_max_an),
-        gnomad_max_af=_cast_to_float(vat_ht.gnomad_max_af),
-        gnomad_max_subpop=_cast_to_str(vat_ht.gnomad_max_subpop),
+        gnomad_all_ac=_cast_to_int(vat_source_ht.gnomad_all_ac),
+        gnomad_all_an=_cast_to_int(vat_source_ht.gnomad_all_an),
+        gnomad_all_af=_cast_to_float(vat_source_ht.gnomad_all_af),
+        gnomad_max_ac=_cast_to_int(vat_source_ht.gnomad_max_ac),
+        gnomad_max_an=_cast_to_int(vat_source_ht.gnomad_max_an),
+        gnomad_max_af=_cast_to_float(vat_source_ht.gnomad_max_af),
+        gnomad_max_subpop=_cast_to_str(vat_source_ht.gnomad_max_subpop),
 
         # Clinical / functional annotations
-        clinvar_classification=_cast_to_str(vat_ht.clinvar_classification),
-        clinvar_phenotype=sanitize_info(vat_ht.clinvar_phenotype),
-        omim_phenotypes_id=_cast_to_str(vat_ht.omim_phenotypes_id),
-        gene_omim_id=_cast_to_str(vat_ht.gene_omim_id),
-        consequence=_cast_to_str(vat_ht.consequence),
-        revel=_cast_to_float(vat_ht.revel),
-        aa_change=_cast_to_str(vat_ht.aa_change),
-        LoF=_cast_to_str(vat_ht.LoF),
-        LoF_filter=sanitize_info(vat_ht.LoF_filter),
-        LoF_flags=sanitize_info(vat_ht.LoF_flags),
-        LoF_info=sanitize_info(vat_ht.LoF_info),
-        rsid=_cast_to_str(vat_ht.dbsnp_rsid),
+        clinvar_classification=_cast_to_str(vat_source_ht.clinvar_classification),
+        clinvar_phenotype=sanitize_info(vat_source_ht.clinvar_phenotype),
+        omim_phenotypes_id=_cast_to_str(vat_source_ht.omim_phenotypes_id),
+        gene_omim_id=_cast_to_str(vat_source_ht.gene_omim_id),
+        consequence=_cast_to_str(vat_source_ht.consequence),
+        revel=_cast_to_float(vat_source_ht.revel),
+        aa_change=_cast_to_str(vat_source_ht.aa_change),
+        LoF=_cast_to_str(vat_source_ht.LoF),
+        LoF_filter=sanitize_info(vat_source_ht.LoF_filter),
+        LoF_flags=sanitize_info(vat_source_ht.LoF_flags),
+        LoF_info=sanitize_info(vat_source_ht.LoF_info),
+        rsid=_cast_to_str(vat_source_ht.dbsnp_rsid),
 
         # SpliceAI scores and distances
-        splice_ai_acceptor_gain_score=_cast_to_float(vat_ht.splice_ai_acceptor_gain_score),
-        splice_ai_acceptor_loss_score=_cast_to_float(vat_ht.splice_ai_acceptor_loss_score),
-        splice_ai_donor_gain_score=_cast_to_float(vat_ht.splice_ai_donor_gain_score),
-        splice_ai_donor_loss_score=_cast_to_float(vat_ht.splice_ai_donor_loss_score),
-        splice_ai_acceptor_gain_distance=_cast_to_int(vat_ht.splice_ai_acceptor_gain_distance),
-        splice_ai_acceptor_loss_distance=_cast_to_int(vat_ht.splice_ai_acceptor_loss_distance),
-        splice_ai_donor_gain_distance=_cast_to_int(vat_ht.splice_ai_donor_gain_distance),
-        splice_ai_donor_loss_distance=_cast_to_int(vat_ht.splice_ai_donor_loss_distance)
+        splice_ai_acceptor_gain_score=_cast_to_float(vat_source_ht.splice_ai_acceptor_gain_score),
+        splice_ai_acceptor_loss_score=_cast_to_float(vat_source_ht.splice_ai_acceptor_loss_score),
+        splice_ai_donor_gain_score=_cast_to_float(vat_source_ht.splice_ai_donor_gain_score),
+        splice_ai_donor_loss_score=_cast_to_float(vat_source_ht.splice_ai_donor_loss_score),
+        splice_ai_acceptor_gain_distance=_cast_to_int(vat_source_ht.splice_ai_acceptor_gain_distance),
+        splice_ai_acceptor_loss_distance=_cast_to_int(vat_source_ht.splice_ai_acceptor_loss_distance),
+        splice_ai_donor_gain_distance=_cast_to_int(vat_source_ht.splice_ai_donor_gain_distance),
+        splice_ai_donor_loss_distance=_cast_to_int(vat_source_ht.splice_ai_donor_loss_distance)
     )
-    return vat_ht.key_by('locus', 'alleles')
+    transcript_ht = vat_source_ht.select(
+        "locus",
+        "alleles",
+        rsid=_cast_to_str(vat_source_ht.dbsnp_rsid),
+        gene_id=_cast_to_str(vat_source_ht.gene_id),
+        gene_symbol=_cast_to_str(vat_source_ht.gene_symbol),
+        transcript=_cast_to_str(vat_source_ht.transcript),
+        is_canonical_transcript=_cast_to_str(vat_source_ht.is_canonical_transcript),
+        consequence=_cast_to_str(vat_source_ht.consequence),
+        aa_change=_cast_to_str(vat_source_ht.aa_change),
+        LoF=_cast_to_str(vat_source_ht.LoF),
+        LoF_filter=sanitize_info(vat_source_ht.LoF_filter),
+        LoF_flags=sanitize_info(vat_source_ht.LoF_flags),
+        LoF_info=sanitize_info(vat_source_ht.LoF_info),
+        gvs_max_af=_cast_to_float(vat_source_ht.gvs_max_af),
+        gvs_max_subpop=_cast_to_str(vat_source_ht.gvs_max_subpop),
+    ).key_by("locus", "alleles")
+    return variant_ht.key_by('locus', 'alleles'), transcript_ht
 
 
 # init
@@ -220,7 +263,7 @@ def main(args):
     samples_ht = hl.import_table(args.SampleList, key='research_id')
 
     annotate_with_vat = not args.SkipVATAnnotations
-    vat_ht = _prepare_vat_ht(args.VATHailTable) if annotate_with_vat else None
+    vat_ht, transcript_vat_ht = _prepare_vat_tables(args.VATHailTable) if annotate_with_vat else (None, None)
 
     if args.BedFile:
         bed = hl.import_table(args.BedFile, delimiter='\t', no_header=True,
@@ -283,6 +326,25 @@ def main(args):
     if annotate_with_vat:
         # Join filtered MT with VAT table for annotations.
         mt_filtered = mt_filtered.annotate_rows(_vat=vat_ht[mt_filtered.row_key])
+
+        filtered_variant_keys = mt_filtered.rows().select()
+        transcript_annotations_ht = transcript_vat_ht.semi_join(filtered_variant_keys)
+        transcript_annotations_ht = transcript_annotations_ht.annotate(
+            chrom=transcript_annotations_ht.locus.contig,
+            pos=transcript_annotations_ht.locus.position,
+            ref=transcript_annotations_ht.alleles[0],
+            alt=transcript_annotations_ht.alleles[1],
+        )
+        transcript_annotations_ht = transcript_annotations_ht.key_by().select(
+            "chrom", "pos", "ref", "alt", *TRANSCRIPT_ANNOTATION_FIELDS
+        )
+        transcript_annotations_tsv = _join_cloud_path(
+            args.OutputBucket,
+            f"{args.OutputPrefix}.transcript_annotations.tsv.bgz",
+        )
+        transcript_annotations_ht.export(transcript_annotations_tsv)
+        with open("transcript_annotations_outpath.txt", "w") as output_path_file:
+            output_path_file.write(transcript_annotations_tsv)
 
     # Create flattened row table for annotation export
     annotations_ht = mt_filtered.rows()

--- a/scripts/filter_and_write_mt.py
+++ b/scripts/filter_and_write_mt.py
@@ -111,6 +111,10 @@ def _prepare_vat_tables(vat_hail_table):
             + ", ".join(missing_fields)
         )
 
+    # Source VAT tables may be keyed by (vid, transcript). Remove that source
+    # key before projections so converted fields can safely retain those names.
+    vat_source_ht = vat_source_ht.key_by()
+
     # Parse the variant identifier (vid) into locus + alleles so we can join
     # with the matrix table.  Expected vid format: contig-position-ref-alt
     # Use maxsplit=3 so dashes inside allele strings are preserved.
@@ -240,6 +244,24 @@ def _prepare_vat_tables(vat_hail_table):
     return variant_ht.key_by('locus', 'alleles'), transcript_ht
 
 
+def _prepare_transcript_annotations(transcript_vat_ht, filtered_variant_keys):
+    transcript_annotations_ht = transcript_vat_ht.semi_join(filtered_variant_keys)
+    transcript_annotations_ht = transcript_annotations_ht.annotate(
+        chrom=transcript_annotations_ht.locus.contig,
+        pos=transcript_annotations_ht.locus.position,
+        ref=transcript_annotations_ht.alleles[0],
+        alt=transcript_annotations_ht.alleles[1],
+    )
+    transcript_annotations_ht = transcript_annotations_ht.order_by(
+        transcript_annotations_ht.locus,
+        transcript_annotations_ht.alleles,
+        transcript_annotations_ht.transcript,
+    )
+    return transcript_annotations_ht.select(
+        "chrom", "pos", "ref", "alt", *TRANSCRIPT_ANNOTATION_FIELDS
+    )
+
+
 # init
 def main(args):
     # Initialize Hail with workflow-configurable local Spark resources.
@@ -328,15 +350,8 @@ def main(args):
         mt_filtered = mt_filtered.annotate_rows(_vat=vat_ht[mt_filtered.row_key])
 
         filtered_variant_keys = mt_filtered.rows().select()
-        transcript_annotations_ht = transcript_vat_ht.semi_join(filtered_variant_keys)
-        transcript_annotations_ht = transcript_annotations_ht.annotate(
-            chrom=transcript_annotations_ht.locus.contig,
-            pos=transcript_annotations_ht.locus.position,
-            ref=transcript_annotations_ht.alleles[0],
-            alt=transcript_annotations_ht.alleles[1],
-        )
-        transcript_annotations_ht = transcript_annotations_ht.key_by().select(
-            "chrom", "pos", "ref", "alt", *TRANSCRIPT_ANNOTATION_FIELDS
+        transcript_annotations_ht = _prepare_transcript_annotations(
+            transcript_vat_ht, filtered_variant_keys
         )
         transcript_annotations_tsv = _join_cloud_path(
             args.OutputBucket,

--- a/tests/test_filter_and_write_mt_contract.py
+++ b/tests/test_filter_and_write_mt_contract.py
@@ -38,6 +38,26 @@ class TranscriptVatContractTests(unittest.TestCase):
         self.assertIn("vid", MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS)
         self.assertIn("dbsnp_rsid", MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS)
 
+    def test_filter_workflow_exposes_optional_transcript_output(self):
+        source = (ROOT / "workflow" / "FilterMT.wdl").read_text()
+        self.assertIn(
+            "File? TranscriptAnnotations = TaskFilterMT.TranscriptAnnotations",
+            source,
+        )
+        self.assertIn(
+            "File? TranscriptAnnotations = if AnnotateWithVAT then "
+            "read_string('transcript_annotations_outpath.txt') else "
+            "'transcript_annotations_outpath.txt'",
+            source,
+        )
+
+    def test_main_workflow_propagates_transcript_output(self):
+        source = (ROOT / "main.wdl").read_text()
+        self.assertIn(
+            "File? TranscriptAnnotations = filter.TranscriptAnnotations",
+            source,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_filter_and_write_mt_contract.py
+++ b/tests/test_filter_and_write_mt_contract.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.modules.setdefault("hail", types.ModuleType("hail"))
+SPEC = importlib.util.spec_from_file_location(
+    "filter_and_write_mt", ROOT / "scripts" / "filter_and_write_mt.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TranscriptVatContractTests(unittest.TestCase):
+    def test_transcript_output_fields_are_complete(self):
+        self.assertEqual(
+            MODULE.TRANSCRIPT_ANNOTATION_FIELDS,
+            (
+                "rsid", "gene_id", "gene_symbol", "transcript",
+                "is_canonical_transcript", "consequence", "aa_change",
+                "LoF", "LoF_filter", "LoF_flags", "LoF_info",
+                "gvs_max_af", "gvs_max_subpop",
+            ),
+        )
+
+    def test_missing_required_fields_are_sorted(self):
+        available = set(MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS) - {
+            "gene_id", "transcript"
+        }
+        self.assertEqual(
+            MODULE._missing_transcript_vat_fields(available),
+            ["gene_id", "transcript"],
+        )
+
+    def test_vid_and_dbsnp_source_fields_are_required(self):
+        self.assertIn("vid", MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS)
+        self.assertIn("dbsnp_rsid", MODULE.REQUIRED_TRANSCRIPT_VAT_FIELDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filter_and_write_mt_hail_integration.py
+++ b/tests/test_filter_and_write_mt_hail_integration.py
@@ -1,0 +1,219 @@
+import csv
+import gzip
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+try:
+    import hail as hl
+except ModuleNotFoundError:  # The real integration test runs in the pinned Hail image.
+    hl = None
+if hl is not None and not hasattr(hl, "init"):
+    hl = None
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_COLUMNS = [
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "rsid",
+    "gene_id",
+    "gene_symbol",
+    "transcript",
+    "is_canonical_transcript",
+    "consequence",
+    "aa_change",
+    "LoF",
+    "LoF_filter",
+    "LoF_flags",
+    "LoF_info",
+    "gvs_max_af",
+    "gvs_max_subpop",
+]
+
+
+def _table_order_by_nodes(ir):
+    nodes = []
+    if type(ir).__name__ == "TableOrderBy":
+        nodes.append(ir)
+    for child in getattr(ir, "children", ()):
+        nodes.extend(_table_order_by_nodes(child))
+    return nodes
+
+
+@unittest.skipIf(hl is None, "requires the pinned Hail integration image")
+class TranscriptVatHailIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        cls.temp_path = Path(cls.temp_dir.name)
+        hl.init(
+            app_name="vat_transcript_integration_test",
+            master="local[2]",
+            tmp_dir=str(cls.temp_path / "hail-tmp"),
+            log=str(cls.temp_path / "hail.log"),
+            quiet=True,
+        )
+        hl.default_reference("GRCh38")
+
+        spec = importlib.util.spec_from_file_location(
+            "filter_and_write_mt_hail_integration",
+            ROOT / "scripts" / "filter_and_write_mt.py",
+        )
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    @classmethod
+    def tearDownClass(cls):
+        hl.stop()
+        cls.temp_dir.cleanup()
+
+    def _vat_row(self, vid, transcript, **values):
+        source_fields = set(self.module.VAT_ANNOTATION_FIELDS)
+        source_fields.update(self.module.REQUIRED_TRANSCRIPT_VAT_FIELDS)
+        row = {field: "" for field in source_fields}
+        row.update(
+            {
+                "vid": vid,
+                "transcript": transcript,
+                "dbsnp_rsid": values.pop("rsid", ""),
+            }
+        )
+        row.update(values)
+        return row
+
+    def test_composite_key_transcript_export_contract(self):
+        vat_rows = [
+            self._vat_row(
+                "2-200-G-T",
+                "ENST0003",
+                rsid="rs200",
+                gene_id="ENSG0003",
+                gene_symbol="GENE3",
+                is_canonical_transcript="true",
+                consequence="missense_variant",
+                aa_change="p.Gly2Val",
+                gvs_max_af="0.003",
+                gvs_max_subpop="eur",
+            ),
+            self._vat_row(
+                "1-100-A-C",
+                "ENST0002",
+                rsid="rs100",
+                gene_id="ENSG0002",
+                gene_symbol="GENE2",
+                is_canonical_transcript="false",
+                consequence="synonymous_variant",
+                aa_change="p.Ala1Ala",
+                gvs_max_af="0.002",
+                gvs_max_subpop="afr",
+            ),
+            self._vat_row(
+                "1-150-C-G",
+                "",
+                rsid="rs150",
+                consequence="intergenic_variant",
+                gvs_max_af="0.004",
+                gvs_max_subpop="amr",
+            ),
+            self._vat_row(
+                "1-100-A-C",
+                "ENST0001",
+                rsid="rs100",
+                gene_id="ENSG0001",
+                gene_symbol="GENE1",
+                is_canonical_transcript="true",
+                consequence="missense_variant",
+                aa_change="p.Ala1Pro",
+                LoF_filter="one;two=three",
+                gvs_max_af="0.001",
+                gvs_max_subpop="sas",
+            ),
+            self._vat_row(
+                "1-50-G-A",
+                "ENST_FILTERED",
+                rsid="rs50",
+                gene_id="ENSG_FILTERED",
+                gene_symbol="FILTERED",
+                is_canonical_transcript="true",
+                consequence="stop_gained",
+                gvs_max_af="0.5",
+                gvs_max_subpop="oth",
+            ),
+        ]
+        vat_path = self.temp_path / "composite-key-vat.ht"
+        hl.Table.parallelize(vat_rows, n_partitions=2).key_by(
+            "vid", "transcript"
+        ).write(str(vat_path), overwrite=True)
+
+        variant_ht, transcript_ht = self.module._prepare_vat_tables(str(vat_path))
+        self.assertEqual(list(variant_ht.key), ["locus", "alleles"])
+        self.assertEqual(list(transcript_ht.key), ["locus", "alleles"])
+
+        # Feed same-variant transcripts through a descending upstream sort; the
+        # IR assertion below requires production to add the approved ascending sort.
+        transcript_ht = transcript_ht.order_by(
+            transcript_ht.locus,
+            transcript_ht.alleles,
+            hl.desc(transcript_ht.transcript),
+        ).key_by("locus", "alleles")
+        retained_keys = hl.Table.parallelize(
+            [
+                {
+                    "locus": hl.Locus("chr2", 200, "GRCh38"),
+                    "alleles": ["G", "T"],
+                },
+                {
+                    "locus": hl.Locus("chr1", 150, "GRCh38"),
+                    "alleles": ["C", "G"],
+                },
+                {
+                    "locus": hl.Locus("chr1", 100, "GRCh38"),
+                    "alleles": ["A", "C"],
+                },
+            ],
+            key=["locus", "alleles"],
+            n_partitions=2,
+        )
+
+        exported_ht = self.module._prepare_transcript_annotations(
+            transcript_ht, retained_keys
+        )
+        order_by_nodes = _table_order_by_nodes(exported_ht._tir)
+        self.assertGreaterEqual(len(order_by_nodes), 1)
+        self.assertEqual(
+            order_by_nodes[0].sort_fields,
+            [("locus", "A"), ("alleles", "A"), ("transcript", "A")],
+        )
+        output_path = self.temp_path / "transcript_annotations.tsv.bgz"
+        exported_ht.export(str(output_path))
+
+        with gzip.open(output_path, "rt", newline="") as input_file:
+            reader = csv.DictReader(input_file, delimiter="\t")
+            rows = list(reader)
+
+        self.assertEqual(reader.fieldnames, EXPECTED_COLUMNS)
+        self.assertEqual(
+            [(row["chrom"], row["pos"]) for row in rows],
+            [("chr1", "100"), ("chr1", "100"), ("chr1", "150"), ("chr2", "200")],
+        )
+        self.assertEqual(
+            [row["transcript"] for row in rows[:2]],
+            ["ENST0001", "ENST0002"],
+        )
+        self.assertEqual(
+            sum(row["chrom"] == "chr1" and row["pos"] == "100" for row in rows),
+            2,
+        )
+        self.assertEqual(
+            next(row for row in rows if row["pos"] == "150")["consequence"],
+            "intergenic_variant",
+        )
+        self.assertNotIn("50", {row["pos"] for row in rows})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filtermt_optional_output_smoke.py
+++ b/tests/test_filtermt_optional_output_smoke.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_WDL = ROOT / "workflow" / "FilterMT.wdl"
+SMOKE_WDL = ROOT / "tests" / "wdl" / "filtermt_optional_output_smoke.wdl"
+OUTPUT_PREFIX = "File? TranscriptAnnotations = if AnnotateWithVAT"
+
+
+def _optional_output_declaration(path):
+    declarations = [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip().startswith(OUTPUT_PREFIX)
+    ]
+    if len(declarations) != 1:
+        raise AssertionError(
+            f"expected one optional transcript output declaration in {path}, "
+            f"found {len(declarations)}"
+        )
+    return declarations[0]
+
+
+@unittest.skipUnless(shutil.which("miniwdl"), "miniwdl is not installed")
+class FilterMTOptionalOutputSmokeTests(unittest.TestCase):
+    def test_false_annotation_flag_yields_absent_transcript_output(self):
+        self.assertEqual(
+            _optional_output_declaration(PRODUCTION_WDL),
+            _optional_output_declaration(SMOKE_WDL),
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            result_path = temp_path / "result.json"
+            subprocess.run(
+                [
+                    "miniwdl",
+                    "run",
+                    str(SMOKE_WDL),
+                    "AnnotateWithVAT=false",
+                    "--dir",
+                    str(temp_path / "run") + "/.",
+                    "--no-cache",
+                    "--as-me",
+                    "--no-color",
+                    "-o",
+                    str(result_path),
+                ],
+                cwd=ROOT,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            result = json.loads(result_path.read_text())
+
+        self.assertIsNone(
+            result["outputs"][
+                "FilterMTOptionalOutputSmoke.TranscriptAnnotations"
+            ]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/wdl/filtermt_optional_output_smoke.wdl
+++ b/tests/wdl/filtermt_optional_output_smoke.wdl
@@ -1,0 +1,34 @@
+version 1.0
+
+workflow FilterMTOptionalOutputSmoke {
+    input {
+        Boolean AnnotateWithVAT = false
+    }
+
+    call EmitOptionalOutput {
+        input:
+            AnnotateWithVAT = AnnotateWithVAT
+    }
+
+    output {
+        File? TranscriptAnnotations = EmitOptionalOutput.TranscriptAnnotations
+    }
+}
+
+task EmitOptionalOutput {
+    input {
+        Boolean AnnotateWithVAT
+    }
+
+    command <<<
+        true
+    >>>
+
+    runtime {
+        docker: "hailgenetics/hail:0.2.134-py3.11"
+    }
+
+    output {
+        File? TranscriptAnnotations = if AnnotateWithVAT then read_string('transcript_annotations_outpath.txt') else 'transcript_annotations_outpath.txt'
+    }
+}

--- a/workflow/FilterMT.wdl
+++ b/workflow/FilterMT.wdl
@@ -46,6 +46,7 @@ workflow FilterMT {
 
     output {
         File PathVCF = TaskFilterMT.PathVCF
+        File? TranscriptAnnotations = TaskFilterMT.TranscriptAnnotations
     }
 }
 
@@ -102,5 +103,6 @@ task TaskFilterMT {
     
     output {
         File PathVCF = read_string('outpath.txt')
+        File? TranscriptAnnotations = if AnnotateWithVAT then read_string('transcript_annotations_outpath.txt') else 'transcript_annotations_outpath.txt'
     }
 }


### PR DESCRIPTION
## Summary

- preserve the existing VCF and one-row-per-variant annotations TSV
- add `<OutputPrefix>.transcript_annotations.tsv.bgz` with one row per retained VAT variant-transcript combination
- expose the companion artifact as optional `File? TranscriptAnnotations` through `FilterMT.wdl` and `main.wdl`
- validate required VAT fields and document regeneration requirements for older VAT Hail Tables

## Why

Gene-matched rare-variant enrichment needs `gene_id`, transcript identity, consequence, and LOFTEE annotations. The prior variant-level lookup dropped the VAT variant-transcript relationship.

## Implementation

The Hail task reads VAT once, normalizes any existing source key, derives separate variant- and transcript-level projections, and semi-joins transcript rows to the filtered MatrixTable variant keys without expanding genotype rows or collecting annotations on the driver. Transcript output is explicitly ordered by locus, alleles, and transcript.

## Validation

- `python3 -m unittest discover -s tests -v` — 7 tests, 6 passed and the pinned-Hail test skipped on the host as intended
- pinned `hailgenetics/hail:0.2.134-py3.11` integration — passed; covers composite `(vid, transcript)` keys, duplicate transcripts, intergenic rows, filtered variants, exact columns, and ordering
- executable miniwdl `AnnotateWithVAT=false` smoke test — passed and returned a null optional output
- Python compilation — passed
- all five production WDL files plus the smoke fixture — passed `miniwdl check`
- `git diff --check origin/main...HEAD` — passed

A full production MatrixTable/cloud run is not included because production inputs and credentials are not available in this checkout.