### PR TITLE
Add LoF carrier table workflows

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -10,5 +10,8 @@ workflows:
     primaryDescriptorPath: /main.wdl
     name: FilterMTAndExportToVCF
   - subclass: WDL
+    primaryDescriptorPath: /workflow/LoFCarrierTable.wdl
+    name: LoFCarrierTable
+  - subclass: WDL
     primaryDescriptorPath: /workflow/TSVtoHailTable.wdl
     name: TSVtoHailTable

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ This is the main, all-in-one workflow. It filters the matrix table, annotates va
 | `SparkShufflePartitions` | Spark SQL shuffle partitions (default: 100) |
 | `MakeDosage` | If `true`, convert the exported VCF to a genotype dosage TSV (default: `false`; `main.wdl` only) |
 | `MakePlink` | If `true`, convert the exported VCF to PLINK 2 pgen/pvar/psam files (default: `false`; `main.wdl` only) |
+| `MakeLoFCarriers` | If `true`, emit long-format sample-gene LoF carrier tables from the exported VCF and transcript annotations (default: `false`; `main.wdl` only; requires `AnnotateWithVAT=true`) |
 | `DosageThreads` | Threads for the optional bcftools dosage task (default: 4; `main.wdl` only) |
 | `PlinkNewIdMaxAlleleLen` | Value passed to PLINK 2 `--new-id-max-allele-len` (default: 200; `main.wdl` only) |
+| `LoFCarrierThreads` | Threads for the optional indexed LoF variant extraction task (default: 4; `main.wdl` only) |
+| `LoFCarrierTaskMemory` | Memory for the optional LoF carrier task (default: `32G`; `main.wdl` only) |
+| `LoFCarrierTaskDisk` | Local disk request for the optional LoF carrier task (default: `local-disk 500 SSD`; `main.wdl` only) |
 
 When running through `main.wdl`, these filter-task runtime inputs are exposed with a `Filter` prefix: `FilterTaskCpu`, `FilterTaskMemory`, `FilterTaskDisk`, `FilterSparkDriverMemory`, `FilterSparkParallelism`, and `FilterSparkShufflePartitions`.
 
@@ -102,7 +106,17 @@ VAT Hail Tables that lack any of these columns must be regenerated from a VAT
 export containing them. No VAT schema validation occurs when annotation is
 disabled.
 
-When running through `main.wdl`, the exported VCF is always indexed. If `MakeDosage` is enabled, the workflow also emits `<FullPrefix>.dose.tsv.gz` and its `.tbi` index. If `MakePlink` is enabled, it emits `<FullPrefix>.pgen`, `<FullPrefix>.pvar`, and `<FullPrefix>.psam`.
+When running through `main.wdl`, the exported VCF is always indexed. If `MakeDosage` is enabled, the workflow also emits `<FullPrefix>.dose.tsv.gz` and its `.tbi` index. If `MakePlink` is enabled, it emits `<FullPrefix>.pgen`, `<FullPrefix>.pvar`, and `<FullPrefix>.psam`. If `MakeLoFCarriers` is enabled with VAT annotations on, it emits `<FullPrefix>.lof_carriers.HC.tsv.gz` and `<FullPrefix>.lof_carriers.HC_or_LC.tsv.gz`.
+
+The LoF carrier outputs are sparse long-format sample-gene tables with one row
+per sample and gene where the sample carries at least one qualifying
+non-reference LoF variant. HC-only uses transcript rows with `LoF == "HC"`;
+HC-or-LC uses `LoF` in `{"HC", "LC"}`. Genotypes with any non-reference allele
+count as carriers. The task first creates a LoF sites file from the transcript
+annotations, then uses `bcftools view -R` against the indexed VCF so only LoF
+variant genotypes are parsed. Output columns are `sample_id`, `gene_id`,
+`gene_symbol`, `has_lof_variant`, `n_lof_variants`, `variant_ids`, and
+`lof_classes`.
 
 For pipeline testing without VAT, set `AnnotateWithVAT = false` and omit `VATHailTable`. The annotations TSV and VCF still include filtered cohort statistics and variant QC fields, but VAT-derived fields are omitted.
 
@@ -120,7 +134,31 @@ with `python3 -m unittest tests.test_filtermt_optional_output_smoke -v`.
 
 ---
 
-### 2. TSVtoHailTable.wdl
+### 2. LoFCarrierTable.wdl
+
+This utility workflow creates sparse long-format LoF carrier tables from an
+exported VCF and the corresponding transcript annotations TSV.
+
+**Inputs:**
+
+| Parameter | Description |
+|---|---|
+| `vcf_file` | Exported bgzipped VCF containing sample genotype fields |
+| `vcf_index` | Tabix index for `vcf_file` |
+| `transcript_annotations_tsv` | Transcript annotations TSV/BGZ emitted by the filter workflow |
+| `output_prefix` | Filename prefix for the carrier outputs |
+| `threads` | Threads for `bcftools view -R` (default: 4) |
+| `task_memory` | Memory for the extraction task (default: `32G`) |
+| `task_disk` | Local disk request for the extraction task (default: `local-disk 500 SSD`) |
+
+**Outputs:**
+
+- `<output_prefix>.lof_carriers.HC.tsv.gz`
+- `<output_prefix>.lof_carriers.HC_or_LC.tsv.gz`
+
+---
+
+### 3. TSVtoHailTable.wdl
 
 This utility workflow converts an AoU Variant Annotation Table (VAT) TSV (or TSV.gz / BGZ) into a Hail table stored in cloud storage. The resulting Hail table is used by `FilterMT.wdl` to efficiently annotate variants at scale, avoiding the overhead of re-importing the flat file on every run.
 
@@ -139,7 +177,7 @@ This utility workflow converts an AoU Variant Annotation Table (VAT) TSV (or TSV
 
 ---
 
-### 3. MTtoVCF.wdl *(legacy — export only)*
+### 4. MTtoVCF.wdl *(legacy — export only)*
 
 > **This workflow is legacy.** The export step has been rolled into `FilterMT.wdl`. Use `FilterMT.wdl` for all new work.
 

--- a/main.wdl
+++ b/main.wdl
@@ -64,8 +64,12 @@ workflow FilterMTAndExportToVCF{
         # Optional VCF post-processing
         Boolean MakeDosage = false
         Boolean MakePlink = false
+        Boolean MakeLoFCarriers = false
         Int DosageThreads = 4
         Int PlinkNewIdMaxAlleleLen = 200
+        Int LoFCarrierThreads = 4
+        String LoFCarrierTaskMemory = "32G"
+        String LoFCarrierTaskDisk = "local-disk 500 SSD"
     }
 
     String FullPrefix = "~{OutputPrefix}.~{SampleSetName}.AC~{MinAlleleCountThreshold}.AN~{AlleleNumberPercentage}.biallelic.~{CallSetName}"
@@ -101,11 +105,17 @@ workflow FilterMTAndExportToVCF{
    call VCFPostProcess.VCFPostProcess as postprocess {
         input:
             vcf_file = filter.PathVCF,
+            vcf_index = IndexVCF.Index,
+            transcript_annotations_tsv = filter.TranscriptAnnotations,
             output_prefix = FullPrefix,
             make_dosage = MakeDosage,
             make_plink = MakePlink,
+            make_lof_carriers = MakeLoFCarriers && AnnotateWithVAT,
             dosage_threads = DosageThreads,
-            plink_new_id_max_allele_len = PlinkNewIdMaxAlleleLen
+            plink_new_id_max_allele_len = PlinkNewIdMaxAlleleLen,
+            lof_carrier_threads = LoFCarrierThreads,
+            lof_carrier_task_memory = LoFCarrierTaskMemory,
+            lof_carrier_task_disk = LoFCarrierTaskDisk
     }
 
     output {
@@ -117,6 +127,8 @@ workflow FilterMTAndExportToVCF{
         File? PlinkPgen = postprocess.PlinkPgen
         File? PlinkPvar = postprocess.PlinkPvar
         File? PlinkPsam = postprocess.PlinkPsam
+        File? LoFCarriersHC = postprocess.LoFCarriersHC
+        File? LoFCarriersHCOrLC = postprocess.LoFCarriersHCOrLC
     }
 }
 

--- a/scripts/extract_lof_carriers.py
+++ b/scripts/extract_lof_carriers.py
@@ -1,0 +1,336 @@
+import argparse
+import csv
+import gzip
+import re
+from collections import defaultdict
+
+
+MISSING_VALUES = {"", ".", "NA", "NaN", "nan", "None"}
+LOF_CLASSES = ("HC", "LC")
+OUTPUT_HEADER = (
+    "sample_id",
+    "gene_id",
+    "gene_symbol",
+    "has_lof_variant",
+    "n_lof_variants",
+    "variant_ids",
+    "lof_classes",
+)
+VARIANT_MAP_HEADER = (
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "gene_id",
+    "gene_symbol",
+    "lof_class",
+)
+
+
+def _open_text(path):
+    if path.endswith((".gz", ".bgz")):
+        return gzip.open(path, "rt", newline="")
+    return open(path, "rt", newline="")
+
+
+def _clean_value(value):
+    value = "" if value is None else value.strip()
+    return "" if value in MISSING_VALUES else value
+
+
+def _variant_id(chrom, pos, ref, alt):
+    return f"{chrom}:{pos}:{ref}:{alt}"
+
+
+def _sort_lof_classes(classes):
+    rank = {lof_class: index for index, lof_class in enumerate(LOF_CLASSES)}
+    return sorted(classes, key=lambda lof_class: rank.get(lof_class, len(rank)))
+
+
+def parse_transcript_annotations(transcript_annotations_tsv):
+    required_columns = {"chrom", "pos", "ref", "alt", "gene_id", "gene_symbol", "LoF"}
+    variant_genes = defaultdict(
+        lambda: defaultdict(lambda: {"gene_symbols": set(), "lof_classes": set()})
+    )
+
+    with _open_text(transcript_annotations_tsv) as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        missing_columns = required_columns - set(reader.fieldnames or [])
+        if missing_columns:
+            raise ValueError(
+                "Transcript annotation TSV is missing required columns: "
+                + ", ".join(sorted(missing_columns))
+            )
+
+        for row in reader:
+            lof_class = _clean_value(row.get("LoF")).upper()
+            if lof_class not in LOF_CLASSES:
+                continue
+
+            gene_id = _clean_value(row.get("gene_id"))
+            if not gene_id:
+                continue
+
+            chrom = _clean_value(row.get("chrom"))
+            pos = _clean_value(row.get("pos"))
+            ref = _clean_value(row.get("ref"))
+            alt = _clean_value(row.get("alt"))
+            if not all((chrom, pos, ref, alt)):
+                continue
+
+            gene_symbol = _clean_value(row.get("gene_symbol")) or "."
+            gene_entry = variant_genes[(chrom, pos, ref, alt)][gene_id]
+            gene_entry["gene_symbols"].add(gene_symbol)
+            gene_entry["lof_classes"].add(lof_class)
+
+    return variant_genes
+
+
+def _iter_variant_map_rows(variant_genes):
+    for (chrom, pos, ref, alt), genes in sorted(variant_genes.items()):
+        for gene_id, gene_entry in sorted(genes.items()):
+            gene_symbols = sorted(gene_entry["gene_symbols"])
+            for lof_class in _sort_lof_classes(gene_entry["lof_classes"]):
+                yield {
+                    "chrom": chrom,
+                    "pos": pos,
+                    "ref": ref,
+                    "alt": alt,
+                    "gene_id": gene_id,
+                    "gene_symbol": ",".join(gene_symbols),
+                    "lof_class": lof_class,
+                }
+
+
+def write_variant_map(variant_genes, variant_map_path):
+    with open(variant_map_path, "wt", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            delimiter="\t",
+            fieldnames=VARIANT_MAP_HEADER,
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        writer.writerows(_iter_variant_map_rows(variant_genes))
+
+
+def write_regions(variant_genes, regions_path):
+    seen_regions = set()
+    with open(regions_path, "wt", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        for chrom, pos, _, _ in sorted(variant_genes):
+            region = (chrom, pos, pos)
+            if region in seen_regions:
+                continue
+            seen_regions.add(region)
+            writer.writerow(region)
+
+
+def read_variant_map(variant_map_path):
+    variant_genes = defaultdict(
+        lambda: defaultdict(lambda: {"gene_symbols": set(), "lof_classes": set()})
+    )
+    with _open_text(variant_map_path) as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        missing_columns = set(VARIANT_MAP_HEADER) - set(reader.fieldnames or [])
+        if missing_columns:
+            raise ValueError(
+                "LoF variant map is missing required columns: "
+                + ", ".join(sorted(missing_columns))
+            )
+
+        for row in reader:
+            chrom = _clean_value(row.get("chrom"))
+            pos = _clean_value(row.get("pos"))
+            ref = _clean_value(row.get("ref"))
+            alt = _clean_value(row.get("alt"))
+            gene_id = _clean_value(row.get("gene_id"))
+            lof_class = _clean_value(row.get("lof_class")).upper()
+            if not all((chrom, pos, ref, alt, gene_id)) or lof_class not in LOF_CLASSES:
+                continue
+
+            gene_symbol = _clean_value(row.get("gene_symbol")) or "."
+            gene_entry = variant_genes[(chrom, pos, ref, alt)][gene_id]
+            gene_entry["gene_symbols"].update(
+                symbol for symbol in gene_symbol.split(",") if symbol
+            )
+            gene_entry["lof_classes"].add(lof_class)
+
+    return variant_genes
+
+
+def _is_non_ref_gt(gt):
+    gt = _clean_value(gt)
+    if not gt:
+        return False
+
+    for allele in re.split(r"[/|]", gt):
+        if allele in MISSING_VALUES or allele == "0":
+            continue
+        try:
+            if int(allele) > 0:
+                return True
+        except ValueError:
+            return True
+    return False
+
+
+def _add_record(records, sample_id, gene_id, gene_entry, variant_id, lof_classes):
+    record = records[(sample_id, gene_id)]
+    record["gene_symbols"].update(gene_entry["gene_symbols"])
+    record["variant_ids"].add(variant_id)
+    record["lof_classes"].update(lof_classes)
+
+
+def collect_lof_carriers(vcf_file, variant_genes):
+    hc_records = defaultdict(
+        lambda: {"gene_symbols": set(), "variant_ids": set(), "lof_classes": set()}
+    )
+    hc_or_lc_records = defaultdict(
+        lambda: {"gene_symbols": set(), "variant_ids": set(), "lof_classes": set()}
+    )
+    sample_ids = []
+
+    with _open_text(vcf_file) as handle:
+        for raw_line in handle:
+            if raw_line.startswith("##"):
+                continue
+            if raw_line.startswith("#CHROM"):
+                fields = raw_line.rstrip("\n").split("\t")
+                sample_ids = fields[9:]
+                continue
+            if raw_line.startswith("#"):
+                continue
+
+            fields = raw_line.rstrip("\n").split("\t")
+            if len(fields) < 10:
+                continue
+
+            chrom, pos, _, ref, alt = fields[:5]
+            key = (chrom, pos, ref, alt)
+            genes_for_variant = variant_genes.get(key)
+            if not genes_for_variant:
+                continue
+
+            format_fields = fields[8].split(":")
+            try:
+                gt_index = format_fields.index("GT")
+            except ValueError:
+                continue
+
+            variant_id = _variant_id(chrom, pos, ref, alt)
+            for sample_id, sample_value in zip(sample_ids, fields[9:]):
+                sample_fields = sample_value.split(":")
+                if gt_index >= len(sample_fields) or not _is_non_ref_gt(sample_fields[gt_index]):
+                    continue
+
+                for gene_id, gene_entry in genes_for_variant.items():
+                    lof_classes = gene_entry["lof_classes"]
+                    if "HC" in lof_classes:
+                        _add_record(
+                            hc_records, sample_id, gene_id, gene_entry, variant_id, {"HC"}
+                        )
+                    hc_or_lc_classes = set(LOF_CLASSES) & lof_classes
+                    if hc_or_lc_classes:
+                        _add_record(
+                            hc_or_lc_records,
+                            sample_id,
+                            gene_id,
+                            gene_entry,
+                            variant_id,
+                            hc_or_lc_classes,
+                        )
+
+    return hc_records, hc_or_lc_records
+
+
+def write_records(records, output_path):
+    with gzip.open(output_path, "wt", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(OUTPUT_HEADER)
+        for (sample_id, gene_id), record in sorted(records.items()):
+            variant_ids = sorted(record["variant_ids"])
+            writer.writerow(
+                [
+                    sample_id,
+                    gene_id,
+                    ",".join(sorted(record["gene_symbols"])),
+                    "true",
+                    len(variant_ids),
+                    ",".join(variant_ids),
+                    ",".join(_sort_lof_classes(record["lof_classes"])),
+                ]
+            )
+
+
+def write_sites_main(args):
+    variant_genes = parse_transcript_annotations(args.TranscriptAnnotations)
+    write_regions(variant_genes, args.Regions)
+    write_variant_map(variant_genes, args.VariantMap)
+
+    print(f"LoF variants: {len(variant_genes)}")
+    print(f"LoF variant-gene mappings: {sum(len(v) for v in variant_genes.values())}")
+
+
+def collect_carriers_main(args):
+    variant_genes = read_variant_map(args.VariantMap)
+    hc_records, hc_or_lc_records = collect_lof_carriers(args.VCF, variant_genes)
+
+    hc_output = f"{args.OutputPrefix}.lof_carriers.HC.tsv.gz"
+    hc_or_lc_output = f"{args.OutputPrefix}.lof_carriers.HC_or_LC.tsv.gz"
+    write_records(hc_records, hc_output)
+    write_records(hc_or_lc_records, hc_or_lc_output)
+
+    print(f"LoF variant-gene mappings: {sum(len(v) for v in variant_genes.values())}")
+    print(f"HC carrier gene rows: {len(hc_records)}")
+    print(f"HC_or_LC carrier gene rows: {len(hc_or_lc_records)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Create long-format sample-gene LoF carrier tables from a VCF and transcript annotations TSV."
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    write_sites_parser = subparsers.add_parser(
+        "write-sites",
+        help="Write a LoF region file and variant-gene map from transcript annotations.",
+    )
+    write_sites_parser.add_argument(
+        "--TranscriptAnnotations",
+        required=True,
+        help="Transcript annotation TSV/BGZ emitted by filter_and_write_mt.py.",
+    )
+    write_sites_parser.add_argument(
+        "--Regions",
+        required=True,
+        help="Output tab-delimited CHROM/POS/END regions file for bcftools -R.",
+    )
+    write_sites_parser.add_argument(
+        "--VariantMap",
+        required=True,
+        help="Output LoF variant-gene map TSV.",
+    )
+    write_sites_parser.set_defaults(func=write_sites_main)
+
+    collect_parser = subparsers.add_parser(
+        "collect-carriers",
+        help="Collect sample-gene LoF carriers from a LoF-only VCF subset.",
+    )
+    collect_parser.add_argument(
+        "--VCF", required=True, help="LoF-only VCF/VCF.GZ/VCF.BGZ with sample GT fields."
+    )
+    collect_parser.add_argument(
+        "--VariantMap",
+        required=True,
+        help="LoF variant-gene map TSV emitted by write-sites.",
+    )
+    collect_parser.add_argument(
+        "--OutputPrefix", required=True, help="Output filename prefix."
+    )
+    collect_parser.set_defaults(func=collect_carriers_main)
+
+    parsed_args = parser.parse_args()
+    if not hasattr(parsed_args, "func"):
+        parser.error("a command is required: write-sites or collect-carriers")
+    parsed_args.func(parsed_args)

--- a/tests/test_extract_lof_carriers.py
+++ b/tests/test_extract_lof_carriers.py
@@ -1,0 +1,184 @@
+import csv
+import gzip
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "extract_lof_carriers.py"
+
+
+def _read_gzip_tsv(path):
+    with gzip.open(path, "rt", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+class ExtractLoFCarriersTests(unittest.TestCase):
+    def test_writes_hc_and_hc_or_lc_sample_gene_tables(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            vcf_path = temp_path / "input.vcf"
+            transcript_path = temp_path / "transcript_annotations.tsv"
+            output_prefix = temp_path / "cohort"
+
+            vcf_path.write_text(
+                "\n".join(
+                    [
+                        "##fileformat=VCFv4.2",
+                        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\tS3",
+                        "chr1\t100\t.\tA\tT\t.\tPASS\t.\tGT:DP\t0/1:10\t0/0:9\t./.:.",
+                        "chr1\t200\t.\tG\tC\t.\tPASS\t.\tGT\t0/0\t1/1\t0/1",
+                        "chr1\t300\t.\tC\tA\t.\tPASS\t.\tGT\t0/1\t0/1\t0/0",
+                        "chr1\t400\t.\tT\tG\t.\tPASS\t.\tGT\t0/1\t0/0\t0/0",
+                    ]
+                )
+                + "\n"
+            )
+            transcript_path.write_text(
+                "\n".join(
+                    [
+                        "chrom\tpos\tref\talt\trsid\tgene_id\tgene_symbol\ttranscript\tis_canonical_transcript\tconsequence\taa_change\tLoF\tLoF_filter\tLoF_flags\tLoF_info\tgvs_max_af\tgvs_max_subpop",
+                        "chr1\t100\tA\tT\t.\tENSG1\tGENE1\tENST1\ttrue\tstop_gained\tp.X\tHC\t.\t.\t.\t.\t.",
+                        "chr1\t100\tA\tT\t.\tENSG1\tGENE1\tENST2\tfalse\tstop_gained\tp.X\tHC\t.\t.\t.\t.\t.",
+                        "chr1\t200\tG\tC\t.\tENSG1\tGENE1\tENST3\ttrue\tsplice_donor_variant\t.\tLC\t.\t.\t.\t.\t.",
+                        "chr1\t300\tC\tA\t.\tENSG2\tGENE2\tENST4\ttrue\tframeshift_variant\t.\tHC\t.\t.\t.\t.\t.",
+                        "chr1\t400\tT\tG\t.\tENSG3\tGENE3\tENST5\ttrue\tmissense_variant\t.\tNA\t.\t.\t.\t.\t.",
+                    ]
+                )
+                + "\n"
+            )
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "write-sites",
+                    "--TranscriptAnnotations",
+                    str(transcript_path),
+                    "--Regions",
+                    str(temp_path / "lof_regions.tsv"),
+                    "--VariantMap",
+                    str(temp_path / "lof_variant_gene_map.tsv"),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(
+                (temp_path / "lof_regions.tsv").read_text().splitlines(),
+                ["chr1\t100\t100", "chr1\t200\t200", "chr1\t300\t300"],
+            )
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "collect-carriers",
+                    "--VCF",
+                    str(vcf_path),
+                    "--VariantMap",
+                    str(temp_path / "lof_variant_gene_map.tsv"),
+                    "--OutputPrefix",
+                    str(output_prefix),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            hc_rows = _read_gzip_tsv(
+                temp_path / "cohort.lof_carriers.HC.tsv.gz"
+            )
+            hc_or_lc_rows = _read_gzip_tsv(
+                temp_path / "cohort.lof_carriers.HC_or_LC.tsv.gz"
+            )
+
+        self.assertEqual(
+            hc_rows,
+            [
+                {
+                    "sample_id": "S1",
+                    "gene_id": "ENSG1",
+                    "gene_symbol": "GENE1",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:100:A:T",
+                    "lof_classes": "HC",
+                },
+                {
+                    "sample_id": "S1",
+                    "gene_id": "ENSG2",
+                    "gene_symbol": "GENE2",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:300:C:A",
+                    "lof_classes": "HC",
+                },
+                {
+                    "sample_id": "S2",
+                    "gene_id": "ENSG2",
+                    "gene_symbol": "GENE2",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:300:C:A",
+                    "lof_classes": "HC",
+                },
+            ],
+        )
+        self.assertEqual(
+            hc_or_lc_rows,
+            [
+                {
+                    "sample_id": "S1",
+                    "gene_id": "ENSG1",
+                    "gene_symbol": "GENE1",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:100:A:T",
+                    "lof_classes": "HC",
+                },
+                {
+                    "sample_id": "S1",
+                    "gene_id": "ENSG2",
+                    "gene_symbol": "GENE2",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:300:C:A",
+                    "lof_classes": "HC",
+                },
+                {
+                    "sample_id": "S2",
+                    "gene_id": "ENSG1",
+                    "gene_symbol": "GENE1",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:200:G:C",
+                    "lof_classes": "LC",
+                },
+                {
+                    "sample_id": "S2",
+                    "gene_id": "ENSG2",
+                    "gene_symbol": "GENE2",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:300:C:A",
+                    "lof_classes": "HC",
+                },
+                {
+                    "sample_id": "S3",
+                    "gene_id": "ENSG1",
+                    "gene_symbol": "GENE1",
+                    "has_lof_variant": "true",
+                    "n_lof_variants": "1",
+                    "variant_ids": "chr1:200:G:C",
+                    "lof_classes": "LC",
+                },
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filter_and_write_mt_contract.py
+++ b/tests/test_filter_and_write_mt_contract.py
@@ -58,6 +58,24 @@ class TranscriptVatContractTests(unittest.TestCase):
             source,
         )
 
+    def test_main_workflow_exposes_lof_carrier_outputs(self):
+        source = (ROOT / "main.wdl").read_text()
+        self.assertIn("Boolean MakeLoFCarriers = false", source)
+        self.assertIn("Int LoFCarrierThreads = 4", source)
+        self.assertIn("vcf_index = IndexVCF.Index", source)
+        self.assertIn(
+            "make_lof_carriers = MakeLoFCarriers && AnnotateWithVAT",
+            source,
+        )
+        self.assertIn(
+            "File? LoFCarriersHC = postprocess.LoFCarriersHC",
+            source,
+        )
+        self.assertIn(
+            "File? LoFCarriersHCOrLC = postprocess.LoFCarriersHCOrLC",
+            source,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/workflow/LoFCarrierTable.wdl
+++ b/workflow/LoFCarrierTable.wdl
@@ -1,0 +1,81 @@
+version 1.0
+
+workflow LoFCarrierTable {
+    input {
+        File vcf_file
+        File vcf_index
+        File transcript_annotations_tsv
+        String output_prefix
+        Int threads = 4
+        String task_memory = "32G"
+        String task_disk = "local-disk 500 SSD"
+    }
+
+    call ExtractLoFCarriers {
+        input:
+            vcf_file = vcf_file,
+            vcf_index = vcf_index,
+            transcript_annotations_tsv = transcript_annotations_tsv,
+            output_prefix = output_prefix,
+            threads = threads,
+            task_memory = task_memory,
+            task_disk = task_disk
+    }
+
+    output {
+        File LoFCarriersHC = ExtractLoFCarriers.lof_carriers_hc
+        File LoFCarriersHCOrLC = ExtractLoFCarriers.lof_carriers_hc_or_lc
+    }
+}
+
+task ExtractLoFCarriers {
+    input {
+        File vcf_file
+        File vcf_index
+        File transcript_annotations_tsv
+        String output_prefix
+        Int threads = 4
+        String task_memory = "32G"
+        String task_disk = "local-disk 500 SSD"
+    }
+
+    command <<<
+        set -euo pipefail
+
+        if [ "~{vcf_index}" != "~{vcf_file}.tbi" ]; then
+            ln -sf "~{vcf_index}" "~{vcf_file}.tbi"
+        fi
+
+        python3 /extract_lof_carriers.py write-sites \
+            --TranscriptAnnotations "~{transcript_annotations_tsv}" \
+            --Regions lof_regions.tsv \
+            --VariantMap lof_variant_gene_map.tsv
+
+        if [ -s lof_regions.tsv ]; then
+            bcftools view --threads ~{threads} \
+                -R lof_regions.tsv \
+                "~{vcf_file}" \
+                -Ov \
+                -o lof_variants.vcf
+        else
+            touch lof_variants.vcf
+        fi
+
+        python3 /extract_lof_carriers.py collect-carriers \
+            --VCF lof_variants.vcf \
+            --VariantMap lof_variant_gene_map.tsv \
+            --OutputPrefix "~{output_prefix}"
+    >>>
+
+    runtime {
+        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils"
+        memory: task_memory
+        cpu: threads
+        disks: task_disk
+    }
+
+    output {
+        File lof_carriers_hc = "~{output_prefix}.lof_carriers.HC.tsv.gz"
+        File lof_carriers_hc_or_lc = "~{output_prefix}.lof_carriers.HC_or_LC.tsv.gz"
+    }
+}

--- a/workflow/VCFPostProcess.wdl
+++ b/workflow/VCFPostProcess.wdl
@@ -1,13 +1,21 @@
 version 1.0
 
+import "LoFCarrierTable.wdl" as LoFCarrierTable
+
 workflow VCFPostProcess {
     input {
         File vcf_file
+        File? vcf_index
+        File? transcript_annotations_tsv
         String output_prefix
         Boolean make_dosage = false
         Boolean make_plink = false
+        Boolean make_lof_carriers = false
         Int dosage_threads = 4
         Int plink_new_id_max_allele_len = 200
+        Int lof_carrier_threads = 4
+        String lof_carrier_task_memory = "32G"
+        String lof_carrier_task_disk = "local-disk 500 SSD"
     }
 
     if (make_dosage) {
@@ -28,12 +36,27 @@ workflow VCFPostProcess {
         }
     }
 
+    if (make_lof_carriers) {
+        call LoFCarrierTable.ExtractLoFCarriers as LoFCarriers {
+            input:
+                vcf_file = vcf_file,
+                vcf_index = select_first([vcf_index]),
+                transcript_annotations_tsv = select_first([transcript_annotations_tsv]),
+                output_prefix = output_prefix,
+                threads = lof_carrier_threads,
+                task_memory = lof_carrier_task_memory,
+                task_disk = lof_carrier_task_disk
+        }
+    }
+
     output {
         File? GenotypeDosage = BcftoolsDosage.dosage
         File? GenotypeDosageIndex = BcftoolsDosage.dosage_index
         File? PlinkPgen = Plink2.pgen
         File? PlinkPvar = Plink2.pvar
         File? PlinkPsam = Plink2.psam
+        File? LoFCarriersHC = LoFCarriers.lof_carriers_hc
+        File? LoFCarriersHCOrLC = LoFCarriers.lof_carriers_hc_or_lc
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a standalone `LoFCarrierTable.wdl` workflow and Dockstore entry
- Add optional `MakeLoFCarriers` outputs to `main.wdl` through `VCFPostProcess`
- Extract LoF sites from transcript annotations, use `bcftools view -R` against the indexed VCF, and aggregate sample-gene HC and HC-or-LC carrier tables
- Add parser/unit coverage and README documentation

## Outputs
- `<prefix>.lof_carriers.HC.tsv.gz`
- `<prefix>.lof_carriers.HC_or_LC.tsv.gz`

## Validation
- `python3 -m py_compile scripts/extract_lof_carriers.py`
- `python3 -m unittest discover -s tests -v`
- `miniwdl check workflow/LoFCarrierTable.wdl workflow/VCFPostProcess.wdl main.wdl`
- `git diff --check`