### PR TITLE
Pin utils Docker image tag

### DIFF
--- a/main.wdl
+++ b/main.wdl
@@ -17,7 +17,7 @@ task IndexVCF {
     >>>
     
     runtime {
-        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils" 
+        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils:main"
         memory: "256G"
         cpu: 64
         disks: "local-disk 1000 SSD"

--- a/workflow/LoFCarrierTable.wdl
+++ b/workflow/LoFCarrierTable.wdl
@@ -68,7 +68,7 @@ task ExtractLoFCarriers {
     >>>
 
     runtime {
-        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils"
+        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils:main"
         memory: task_memory
         cpu: threads
         disks: task_disk


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/aou-multiomics-analysis/mttovcf/utils` to `:main` in `IndexVCF`
- Pin the standalone LoF carrier workflow to `ghcr.io/aou-multiomics-analysis/mttovcf/utils:main`

## Why
Cloud Batch defaults untagged images to `:latest`; GHCR does not publish a `latest` manifest for the utils image, so standalone LoF carrier runs failed while pulling Docker images with `manifest unknown`.

## Validation
- `miniwdl check workflow/LoFCarrierTable.wdl workflow/VCFPostProcess.wdl main.wdl`
- `git diff --check`