### PR TITLE
Add LoF carrier Docker image

### DIFF
--- a/.github/workflows/lof-carriers.yaml
+++ b/.github/workflows/lof-carriers.yaml
@@ -1,0 +1,49 @@
+name: LoF Carrier Docker Image CI
+
+on:
+  push:
+    paths:
+      - 'envs/lof-carriers/**'
+      - 'scripts/extract_lof_carriers.py'
+    branches:
+      - main
+      - develop
+  pull_request:
+    paths:
+      - 'envs/lof-carriers/**'
+      - 'scripts/extract_lof_carriers.py'
+    branches:
+      - main
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io with docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/lof-carriers
+
+      - name: Build and push docker container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: envs/lof-carriers/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ count as carriers. The task first creates a LoF sites file from the transcript
 annotations, then uses `bcftools view -R` against the indexed VCF so only LoF
 variant genotypes are parsed. Output columns are `sample_id`, `gene_id`,
 `gene_symbol`, `has_lof_variant`, `n_lof_variants`, `variant_ids`, and
-`lof_classes`.
+`lof_classes`. The task uses a dedicated lightweight Docker image,
+`ghcr.io/aou-multiomics-analysis/mttovcf/lof-carriers:main`, with Python and
+bcftools installed.
 
 For pipeline testing without VAT, set `AnnotateWithVAT = false` and omit `VATHailTable`. The annotations TSV and VCF still include filtered cohort statistics and variant QC fields, but VAT-derived fields are omitted.
 

--- a/envs/lof-carriers/Dockerfile
+++ b/envs/lof-carriers/Dockerfile
@@ -1,0 +1,22 @@
+FROM mambaorg/micromamba:1.5.3
+
+ENV MAMBA_DOCKERFILE_ACTIVATE=1
+ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN micromamba install -y -n base -c conda-forge -c bioconda \
+    conda-forge::python=3.11 \
+    bioconda::bcftools \
+    bioconda::htslib \
+    && micromamba clean -a -y
+
+USER root
+RUN ln -sf /opt/conda/bin/python /usr/local/bin/python \
+    && ln -sf /opt/conda/bin/python3 /usr/local/bin/python3 \
+    && ln -sf /opt/conda/bin/bcftools /usr/local/bin/bcftools \
+    && ln -sf /opt/conda/bin/bgzip /usr/local/bin/bgzip \
+    && ln -sf /opt/conda/bin/tabix /usr/local/bin/tabix
+USER mambauser
+
+COPY scripts/extract_lof_carriers.py /extract_lof_carriers.py
+
+CMD ["bash"]

--- a/tests/test_filter_and_write_mt_contract.py
+++ b/tests/test_filter_and_write_mt_contract.py
@@ -76,6 +76,13 @@ class TranscriptVatContractTests(unittest.TestCase):
             source,
         )
 
+    def test_lof_carrier_workflow_uses_dedicated_image(self):
+        source = (ROOT / "workflow" / "LoFCarrierTable.wdl").read_text()
+        self.assertIn(
+            'docker: "ghcr.io/aou-multiomics-analysis/mttovcf/lof-carriers:main"',
+            source,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/workflow/LoFCarrierTable.wdl
+++ b/workflow/LoFCarrierTable.wdl
@@ -68,7 +68,7 @@ task ExtractLoFCarriers {
     >>>
 
     runtime {
-        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/utils:main"
+        docker: "ghcr.io/aou-multiomics-analysis/mttovcf/lof-carriers:main"
         memory: task_memory
         cpu: threads
         disks: task_disk


### PR DESCRIPTION
## Summary
- Add a dedicated `envs/lof-carriers/Dockerfile` with Python 3.11, bcftools, htslib, bgzip, and tabix
- Add a GitHub Actions workflow to publish `ghcr.io/aou-multiomics-analysis/mttovcf/lof-carriers:main`
- Point `LoFCarrierTable.wdl` at the dedicated image instead of the shared utils image

## Why
The standalone LoF carrier workflow needs both `python3` and `bcftools`. The shared utils image had bcftools but the run failed with `/mnt/disks/cromwell_root/script: line 36: python3: command not found`. This isolates the LoF carrier runtime from the Hail images and makes the required commands available on the system PATH.

## Validation
- Built `mttovcf-lof-carriers:test` locally
- Verified `python3`, `bcftools`, and `tabix` are available inside the image
- `python3 -m py_compile scripts/extract_lof_carriers.py`
- `python3 -m unittest discover -s tests -v`
- `miniwdl check workflow/LoFCarrierTable.wdl workflow/VCFPostProcess.wdl main.wdl`
- `git diff --check`