### PR TITLE
Fix Hail LoF class membership

### DIFF
--- a/scripts/extract_lof_carriers_hail.py
+++ b/scripts/extract_lof_carriers_hail.py
@@ -60,7 +60,7 @@ def _prepare_lof_variant_gene_table(vat_hail_table):
         _text_is_defined(vat_ht.vid)
         & _text_is_defined(vat_ht.gene_id)
         & _text_is_defined(vat_ht.LoF)
-        & hl.literal(LOF_CLASSES).contains(vat_ht.LoF)
+        & hl.literal(set(LOF_CLASSES)).contains(vat_ht.LoF)
     )
 
     vat_ht = vat_ht.annotate(_parts=vat_ht.vid.split("-", 4))
@@ -152,7 +152,7 @@ def _variant_id(ht):
 
 
 def _build_carrier_table(entries_ht, lof_classes):
-    lof_class_literal = hl.literal(lof_classes)
+    lof_class_literal = hl.literal(set(lof_classes))
     carrier_ht = entries_ht.filter(
         lof_class_literal.contains(entries_ht.lof_genes.lof_class)
     )

--- a/tests/test_filter_and_write_mt_contract.py
+++ b/tests/test_filter_and_write_mt_contract.py
@@ -110,6 +110,21 @@ class TranscriptVatContractTests(unittest.TestCase):
             workflow_source,
         )
 
+    def test_hail_lof_membership_uses_hail_sets(self):
+        source = (ROOT / "scripts" / "extract_lof_carriers_hail.py").read_text()
+        self.assertIn(
+            "hl.literal(set(LOF_CLASSES)).contains(vat_ht.LoF)",
+            source,
+        )
+        self.assertIn(
+            "lof_class_literal = hl.literal(set(lof_classes))",
+            source,
+        )
+        self.assertIn(
+            "lof_class_literal.contains(entries_ht.lof_genes.lof_class)",
+            source,
+        )
+
         dockstore_source = (ROOT / ".dockstore.yml").read_text()
         self.assertIn(
             "primaryDescriptorPath: /workflow/HailLoFCarrierTable.wdl",


### PR DESCRIPTION
## Summary
- convert LoF class literals to Hail sets before calling `.contains()`
- add a regression contract covering both HC and HC-or-LC paths

## Root cause
Hail interpreted the Python tuple as a `TupleExpression`, which does not implement `.contains()`.

## Validation
- `python3 -m unittest discover -s tests -v` (12 passed, 1 intentional skip)
- `python3 -m py_compile scripts/extract_lof_carriers_hail.py`
- `miniwdl check workflow/HailLoFCarrierTable.wdl`